### PR TITLE
fix: embedding 向量維度 1536 → 1024 配合 bge-m3

### DIFF
--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -747,7 +747,7 @@ model KmArticle {
   version        String?                      @default("1.0")
   teamId         String?                      @db.Uuid
   metadata       Json?
-  embedding      Unsupported("vector(1536)")?
+  embedding      Unsupported("vector(1024)")?
   embeddingModel String?
   viewCount      Int                          @default(0)
   helpfulCount   Int                          @default(0)
@@ -764,7 +764,7 @@ model LongTermMemory {
   id             String                       @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   contactId      String                       @db.Uuid
   content        String
-  embedding      Unsupported("vector(1536)")?
+  embedding      Unsupported("vector(1024)")?
   embeddingModel String?
   metadata       Json?
   createdAt      DateTime                     @default(now())


### PR DESCRIPTION
## Summary
- `schema.prisma` 的 `KmArticle.embedding` 和 `LongTermMemory.embedding` 由 `vector(1536)` 改為 `vector(1024)`
- 配合 bge-m3 模型實際輸出維度（1024 維）

## 背景
UAT 執行 `bulk-embed` 時報錯：`ERROR: expected 1536 dimensions, not 1024`
UAT DB 已手動 `ALTER TABLE` 修正，此 PR 同步程式碼定義。

## Test plan
- [ ] `prisma db push` 不報錯
- [ ] `POST /knowledge/bulk-embed` 向量化正常寫入