### PR TITLE
feat: per-tenant Embedding/Chat 設定 + Clarify 追問 + Partner Ingest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 .env.web
 .env.prod
 *.log
+logs/
 .turbo/
 .DS_Store
 coverage/

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -27,6 +27,7 @@ const envSchema = z.object({
   OLLAMA_CHAT_MODEL: z.string().default('qwen2.5:3b'),
   KB_SIMILARITY_THRESHOLD: z.coerce.number().min(0).max(1).default(0.72),
   KB_AUTO_REPLY_ENABLED: z.string().transform((v) => v === 'true').default('true'),
+  GEMINI_API_KEY: z.string().optional(),
   S3_ENDPOINT: z.string().default('http://localhost:9000'),
   S3_ACCESS_KEY: z.string().default('minioadmin'),
   S3_SECRET_KEY: z.string().default('minioadmin'),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,14 @@
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import dotenv from 'dotenv';
+
+// Load env BEFORE any module that captures process.env at import time
+// (e.g. BullMQ Queue constructed with `connection: { url: process.env.REDIS_URL }`
+// in notification.worker.ts / automation.worker.ts).
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+dotenv.config({ path: resolve(__dirname, '..', '..', '..', '.env') });
+
 import Fastify from 'fastify';
 import multipart from '@fastify/multipart';
 
@@ -51,12 +59,6 @@ import { setupBroadcastScheduler } from './modules/marketing/broadcast.scheduler
 import { setupCsatScheduler } from './modules/csat/csat.scheduler.js';
 import { setupSlaWorker } from './modules/sla/sla.worker.js';
 import { registerChannelPlugin, linePlugin, fbPlugin, webchatPlugin } from '@open333crm/channel-plugins';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const envPath = resolve(__dirname, '..', '..', '..', '.env');
-
-dotenv.config({ path: envPath });
 
 export async function bootstrap() {
   const config = loadEnvConfig();

--- a/apps/api/src/modules/ai/ai.routes.ts
+++ b/apps/api/src/modules/ai/ai.routes.ts
@@ -34,7 +34,7 @@ export default async function aiRoutes(fastify: FastifyInstance) {
       .object({ text: z.string().min(1) })
       .parse(request.body);
 
-    const result = await analyzeSentiment(text);
+    const result = await analyzeSentiment(fastify.prisma, request.agent.tenantId, text);
     return reply.send(success(result));
   });
 
@@ -44,7 +44,7 @@ export default async function aiRoutes(fastify: FastifyInstance) {
       .object({ text: z.string().min(1) })
       .parse(request.body);
 
-    const result = await classifyIssue(text);
+    const result = await classifyIssue(fastify.prisma, request.agent.tenantId, text);
     return reply.send(success(result));
   });
 }

--- a/apps/api/src/modules/ai/ai.service.ts
+++ b/apps/api/src/modules/ai/ai.service.ts
@@ -4,7 +4,7 @@
 
 import type { PrismaClient } from '@prisma/client';
 import { generateEmbedding, searchSimilarArticles } from '../embedding/embedding.service.js';
-import { generateReply, CRM_REPLY_SYSTEM_PROMPT, SUMMARIZE_SYSTEM_PROMPT } from './llm.service.js';
+import { generateReply } from './llm.service.js';
 import { logger } from '@open333crm/core';
 
 export async function suggestReply(prisma: PrismaClient, conversationId: string) {
@@ -37,11 +37,12 @@ export async function suggestReply(prisma: PrismaClient, conversationId: string)
   }
 
   try {
-    const queryEmbedding = await generateEmbedding(userText);
-    const results = await searchSimilarArticles(prisma, queryEmbedding, conversation.tenantId, {
-      topK: 3,
-      threshold: 0.3,
-    });
+    const queryEmbedding = await generateEmbedding(prisma, conversation.tenantId, userText);
+    const results = await searchSimilarArticles(
+      prisma,
+      queryEmbedding,
+      conversation.tenantId,
+    );
 
     if (results.length === 0) {
       return { suggestions: [] };
@@ -53,7 +54,7 @@ export async function suggestReply(prisma: PrismaClient, conversationId: string)
         const kbContext = `【${r.title}】\n${(r.content || r.summary).slice(0, 1500)}`;
         let text: string;
         try {
-          text = await generateReply(CRM_REPLY_SYSTEM_PROMPT, userText, kbContext);
+          text = await generateReply(prisma, conversation.tenantId, userText, kbContext);
         } catch {
           // Fallback to article content/summary if LLM fails
           text = r.content || r.summary || r.title;
@@ -112,7 +113,13 @@ export async function summarizeConversation(prisma: PrismaClient, conversationId
     .join('\n');
 
   try {
-    const summary = await generateReply(SUMMARIZE_SYSTEM_PROMPT, transcript, '');
+    const summary = await generateReply(
+      prisma,
+      conversation.tenantId,
+      transcript,
+      '',
+      { promptKind: 'summarize' },
+    );
     return { summary };
   } catch (err) {
     // Fallback to static template if LLM fails

--- a/apps/api/src/modules/ai/classify.service.ts
+++ b/apps/api/src/modules/ai/classify.service.ts
@@ -2,6 +2,7 @@
  * Issue Classification Service — uses Ollama LLM to categorize customer issues.
  */
 
+import type { PrismaClient } from '@prisma/client';
 import { generateReply } from './llm.service.js';
 import { logger } from '@open333crm/core';
 
@@ -57,9 +58,15 @@ function keywordFallback(text: string): ClassifyResult {
   return { category: '其他', confidence: 0.3 };
 }
 
-export async function classifyIssue(text: string): Promise<ClassifyResult> {
+export async function classifyIssue(
+  prisma: PrismaClient,
+  tenantId: string,
+  text: string,
+): Promise<ClassifyResult> {
   try {
-    const raw = await generateReply(CLASSIFY_SYSTEM_PROMPT, text, '');
+    const raw = await generateReply(prisma, tenantId, text, '', {
+      overrideSystemPrompt: CLASSIFY_SYSTEM_PROMPT,
+    });
 
     const jsonMatch = raw.match(/\{[\s\S]*?\}/);
     if (jsonMatch) {

--- a/apps/api/src/modules/ai/kb-autoreply.service.ts
+++ b/apps/api/src/modules/ai/kb-autoreply.service.ts
@@ -1,23 +1,35 @@
 /**
  * KB Auto-Reply Service
  *
- * When an inbound message arrives in a BOT_HANDLED conversation,
- * searches the knowledge base for similar articles and automatically
- * replies based on confidence tiers:
- *   >= 0.80  — direct reply with article summary
- *   0.50–0.80 — reply + human-handoff prompt
- *   < 0.50  — no reply (let automation or agent handle it)
+ * When an inbound message arrives in a BOT_HANDLED conversation, decide what
+ * to do based on KB similarity tiers:
+ *   >= 0.80               — direct LLM reply grounded in KB
+ *   threshold–0.80        — LLM reply grounded in KB + handoff prompt appended
+ *   < threshold (or no KB)— **clarify**: ask one question to gather more info,
+ *                           bounded by clarifyMaxAttempts (then handoff)
+ *
+ * The LLM now receives the recent conversation history (last 10 messages) so
+ * follow-up turns make sense and clarification questions don't repeat earlier
+ * answers.
  */
 
-import type { PrismaClient } from '@prisma/client';
+import type { PrismaClient, Prisma } from '@prisma/client';
 import type { Server } from 'socket.io';
 import { getConfig } from '../../config/env.js';
 import { generateEmbedding, searchSimilarArticles } from '../embedding/embedding.service.js';
-import { generateReply, CRM_REPLY_SYSTEM_PROMPT } from './llm.service.js';
+import { getEmbeddingSettings } from '../settings/embedding-settings.service.js';
+import { getChatSettings } from '../settings/chat-settings.service.js';
+import { generateReply, CLARIFY_SYSTEM_PROMPT } from './llm.service.js';
+import type { HistoryMessage } from './llm.service.js';
 import { deliverToChannel } from '../conversation/conversation.service.js';
 import { logger } from '@open333crm/core';
 
 const HANDOFF_PROMPT = '需要真人客服協助嗎？請輸入「真人」或「客服」即可轉接。';
+const CLARIFY_HANDOFF_FALLBACK =
+  '不好意思我這邊還沒辦法判斷您的需求，已為您轉接客服人員，請稍候。';
+const HISTORY_LIMIT = 10;
+
+type ReplyKind = 'kb_high_confidence' | 'kb_with_handoff' | 'clarify' | 'clarify_handoff';
 
 export async function attemptKbAutoReply(
   prisma: PrismaClient,
@@ -28,7 +40,7 @@ export async function attemptKbAutoReply(
 ): Promise<boolean> {
   const config = getConfig();
 
-  // 1. Check if KB auto-reply is enabled
+  // 1. Global enable check
   if (!config.KB_AUTO_REPLY_ENABLED) return false;
 
   // 2. Only proceed for BOT_HANDLED conversations
@@ -45,59 +57,102 @@ export async function attemptKbAutoReply(
       },
     },
   });
-
   if (!conversation) return false;
 
-  // 3. Check channel botMode setting
-  const settings = (conversation.channel.settings || {}) as Record<string, unknown>;
-  const botMode = settings.botMode as string | undefined;
+  // 3. Channel botMode gating
+  const channelSettings = (conversation.channel.settings || {}) as Record<string, unknown>;
+  const botMode = channelSettings.botMode as string | undefined;
   if (botMode === 'off' || botMode === 'keyword') return false;
 
-  // 4. Generate embedding for inbound message
+  // 4. Load tenant chat settings (clarify thresholds + system prompts)
+  const chatSettings = await getChatSettings(prisma, tenantId);
+
+  // 5. Fetch conversation history (excluding the just-arrived message we're replying to)
+  const history = await loadHistory(prisma, conversationId);
+
+  // 6. Generate embedding for inbound message
   let queryEmbedding: number[];
   try {
-    queryEmbedding = await generateEmbedding(messageText);
+    queryEmbedding = await generateEmbedding(prisma, tenantId, messageText);
   } catch (err) {
     logger.error('[KbAutoReply] Failed to generate embedding:', err);
     return false;
   }
 
-  // 5. Search KB for similar articles
+  // 7. KB similarity search
+  const embeddingSettings = await getEmbeddingSettings(prisma, tenantId);
   const results = await searchSimilarArticles(prisma, queryEmbedding, tenantId, {
-    topK: 3,
-    threshold: 0.3,
+    topK: embeddingSettings.topK,
+    threshold: embeddingSettings.threshold,
   });
-  logger.info(`[KbAutoReply] searchSimilarArticles returned ${results.length} result(s) for conv ${conversationId}`);
-  if (results.length === 0) return false;
-
   const topResult = results[0];
+  const topSimilarity = topResult?.similarity ?? 0;
+  logger.info(
+    `[KbAutoReply] conv=${conversationId} kbResults=${results.length} topSim=${topSimilarity.toFixed(3)}`,
+  );
 
-  // 6. Build KB context from top results (truncate to avoid LLM timeout)
-  const kbContext = results
-    .map((r, i) => `【文章${i + 1}】${r.title}\n${(r.content || r.summary).slice(0, 1500)}`)
-    .join('\n\n');
-
+  // 8. Decide reply path
+  const needsClarify = !topResult || topSimilarity < chatSettings.clarifyThreshold;
   let replyText: string;
-  try {
-    const llmReply = await generateReply(CRM_REPLY_SYSTEM_PROMPT, messageText, kbContext);
-    if (topResult.similarity >= 0.80) {
-      replyText = llmReply;
+  let replyKind: ReplyKind;
+  let metadataExtras: Record<string, unknown> = {};
+
+  if (needsClarify) {
+    // Track clarify attempts in conversation.metadata to avoid loops
+    const convMeta = (conversation.metadata ?? {}) as Record<string, unknown>;
+    const prevAttempts = Number(convMeta.clarifyAttempts ?? 0);
+    const nextAttempts = prevAttempts + 1;
+
+    if (prevAttempts >= chatSettings.clarifyMaxAttempts) {
+      replyText = CLARIFY_HANDOFF_FALLBACK;
+      replyKind = 'clarify_handoff';
+      metadataExtras = { clarifyAttempts: prevAttempts };
     } else {
-      // 0.50–0.80 range: append handoff prompt
-      replyText = `${llmReply}\n\n${HANDOFF_PROMPT}`;
+      try {
+        const overridePrompt =
+          chatSettings.clarifySystemPrompt || CLARIFY_SYSTEM_PROMPT;
+        const llmReply = await generateReply(prisma, tenantId, messageText, '', {
+          overrideSystemPrompt: overridePrompt,
+          history,
+        });
+        replyText = llmReply;
+        replyKind = 'clarify';
+        metadataExtras = { clarifyAttempts: nextAttempts };
+      } catch (err) {
+        logger.error('[KbAutoReply] Clarify generation failed, handing off:', err);
+        replyText = CLARIFY_HANDOFF_FALLBACK;
+        replyKind = 'clarify_handoff';
+        metadataExtras = { clarifyAttempts: prevAttempts };
+      }
     }
-  } catch (err) {
-    // Fallback: use article content/summary directly if LLM fails
-    logger.error('[KbAutoReply] LLM generation failed, falling back to article content:', err);
-    const fallbackText = topResult.content || topResult.summary || topResult.title;
-    if (topResult.similarity >= 0.80) {
-      replyText = fallbackText;
-    } else {
-      replyText = `${fallbackText}\n\n${HANDOFF_PROMPT}`;
+  } else {
+    // KB has a useful match — use it as grounded context
+    const kbContext = results
+      .map((r, i) => `【文章${i + 1}】${r.title}\n${(r.content || r.summary).slice(0, 1500)}`)
+      .join('\n\n');
+
+    try {
+      const llmReply = await generateReply(prisma, tenantId, messageText, kbContext, { history });
+      if (topSimilarity >= 0.80) {
+        replyText = llmReply;
+        replyKind = 'kb_high_confidence';
+      } else {
+        replyText = `${llmReply}\n\n${HANDOFF_PROMPT}`;
+        replyKind = 'kb_with_handoff';
+      }
+      // Successful KB answer resets clarify attempts
+      metadataExtras = { clarifyAttempts: 0 };
+    } catch (err) {
+      logger.error('[KbAutoReply] LLM generation failed, falling back to article content:', err);
+      const fallbackText = topResult.content || topResult.summary || topResult.title;
+      replyText =
+        topSimilarity >= 0.80 ? fallbackText : `${fallbackText}\n\n${HANDOFF_PROMPT}`;
+      replyKind = topSimilarity >= 0.80 ? 'kb_high_confidence' : 'kb_with_handoff';
+      metadataExtras = { clarifyAttempts: 0 };
     }
   }
 
-  // 7. Create BOT message
+  // 9. Persist BOT message
   const now = new Date();
   const botMessage = await prisma.message.create({
     data: {
@@ -108,29 +163,28 @@ export async function attemptKbAutoReply(
       content: { text: replyText },
       metadata: {
         source: 'kb_auto_reply',
-        confidence: topResult.similarity,
-        articleId: topResult.id,
-        articleTitle: topResult.title,
-        allResults: results.map((r) => ({
-          id: r.id,
-          title: r.title,
-          similarity: r.similarity,
-        })),
+        replyKind,
+        confidence: topSimilarity,
+        articleId: topResult?.id,
+        articleTitle: topResult?.title,
+        allResults: results.map((r) => ({ id: r.id, title: r.title, similarity: r.similarity })),
       },
       createdAt: now,
     },
   });
 
-  // 8. Update conversation
+  // 10. Update conversation (counters + clarifyAttempts)
+  const existingMeta = (conversation.metadata ?? {}) as Record<string, unknown>;
   await prisma.conversation.update({
     where: { id: conversationId },
     data: {
       botRepliesCount: { increment: 1 },
       lastMessageAt: now,
+      metadata: { ...existingMeta, ...metadataExtras } as Prisma.InputJsonValue,
     },
   });
 
-  // 9. Emit WebSocket events
+  // 11. Real-time
   const wsPayload = {
     conversationId,
     message: {
@@ -148,12 +202,44 @@ export async function attemptKbAutoReply(
   io.to(`conversation:${conversationId}`).emit('message.new', wsPayload);
   io.to(`tenant:${tenantId}`).emit('message.new', wsPayload);
 
-  // 10. Deliver reply to actual channel via plugin
+  // 12. Deliver to actual channel
   await deliverToChannel(prisma, conversationId, replyText);
 
   logger.info(
-    `[KbAutoReply] Replied to conversation ${conversationId} (confidence: ${topResult.similarity.toFixed(3)}, article: ${topResult.title})`,
+    `[KbAutoReply] conv=${conversationId} kind=${replyKind} sim=${topSimilarity.toFixed(3)}`,
   );
 
   return true;
+}
+
+/**
+ * Fetch the last HISTORY_LIMIT messages of the conversation as
+ * user/assistant turns. The just-arrived inbound message is excluded — we
+ * pass it separately via `userMessage`.
+ */
+async function loadHistory(
+  prisma: PrismaClient,
+  conversationId: string,
+): Promise<HistoryMessage[]> {
+  const rows = await prisma.message.findMany({
+    where: { conversationId },
+    orderBy: { createdAt: 'desc' },
+    take: HISTORY_LIMIT + 1,
+    select: { direction: true, senderType: true, content: true },
+  });
+  // Drop the most recent inbound (the one we're replying to right now).
+  const trimmed = rows.length > 0 && rows[0].direction === 'INBOUND' ? rows.slice(1) : rows;
+
+  return trimmed
+    .reverse()
+    .map((m) => {
+      const text =
+        typeof m.content === 'object' && m.content !== null
+          ? ((m.content as { text?: string }).text ?? '')
+          : '';
+      if (!text) return null;
+      const role: 'user' | 'assistant' = m.direction === 'INBOUND' ? 'user' : 'assistant';
+      return { role, content: text };
+    })
+    .filter((m): m is HistoryMessage => m !== null);
 }

--- a/apps/api/src/modules/ai/llm.service.ts
+++ b/apps/api/src/modules/ai/llm.service.ts
@@ -1,79 +1,21 @@
 /**
- * LLM Service — calls Ollama chat API for RAG-based reply generation.
+ * LLM Service — generates RAG replies via the per-tenant chat provider.
+ *
+ * Provider (Ollama / Gemini), model, temperature, max tokens, and system
+ * prompts are all loaded from TenantSettings at call time. Defaults below
+ * are used as fallback when a tenant's prompt fields are empty strings.
  */
 
-import { getConfig } from '../../config/env.js';
+import type { PrismaClient } from '@prisma/client';
+import { getChatProvider } from './providers/index.js';
+import type { HistoryMessage } from './providers/index.js';
+import { getChatSettings } from '../settings/chat-settings.service.js';
 
-interface ChatMessage {
-  role: 'system' | 'user' | 'assistant';
-  content: string;
-}
-
-interface OllamaChatResponse {
-  message?: { content: string };
-}
-
-const LLM_TIMEOUT_MS = 120_000;
+export type { HistoryMessage } from './providers/index.js';
 
 /**
- * Generate a reply using Ollama chat model with KB context injected as system prompt.
- */
-export async function generateReply(
-  systemPrompt: string,
-  userMessage: string,
-  kbContext: string,
-): Promise<string> {
-  const config = getConfig();
-  const url = `${config.OLLAMA_BASE_URL}/api/chat`;
-
-  const fullSystemPrompt = kbContext
-    ? `${systemPrompt}\n\n以下是相關知識庫內容，請根據這些內容回答客戶問題：\n${kbContext}`
-    : systemPrompt;
-
-  const messages: ChatMessage[] = [
-    { role: 'system', content: fullSystemPrompt },
-    { role: 'user', content: userMessage },
-  ];
-
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), LLM_TIMEOUT_MS);
-
-  try {
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        model: config.OLLAMA_CHAT_MODEL,
-        messages,
-        stream: false,
-        options: {
-          temperature: 0.3,
-          num_predict: 500,
-        },
-      }),
-      signal: controller.signal,
-    });
-
-    if (!response.ok) {
-      const errBody = await response.text();
-      throw new Error(`Ollama chat failed (${response.status}): ${errBody}`);
-    }
-
-    const data = (await response.json()) as OllamaChatResponse;
-    const text = data.message?.content?.trim();
-
-    if (!text) {
-      throw new Error('Ollama returned empty chat response');
-    }
-
-    return text;
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-/**
- * CRM customer service system prompt (used for auto-reply and suggest).
+ * Default CRM customer-service system prompt. Used when a tenant has not
+ * customized its chatSystemPrompt yet (empty string).
  */
 export const CRM_REPLY_SYSTEM_PROMPT =
   '你是「Open333」品牌的專業客服助手，負責回答客戶關於家電產品（冰箱、洗衣機、冷氣、電視等）的問題。\n' +
@@ -87,9 +29,68 @@ export const CRM_REPLY_SYSTEM_PROMPT =
   '7. 結尾可適當加上「還有其他需要幫忙的嗎？」';
 
 /**
- * System prompt for conversation summarization.
+ * Default conversation summarization system prompt.
  */
 export const SUMMARIZE_SYSTEM_PROMPT =
   '你是一位客服系統的對話分析助手。請根據以下對話記錄，用繁體中文產生簡潔的對話摘要。' +
   '摘要應包含：客戶的主要問題或需求、目前的處理狀態、以及後續建議的行動。' +
   '請用 2-4 句話完成摘要，不要超過 200 字。';
+
+/**
+ * Default system prompt used when KB confidence is too low to answer directly.
+ * The bot should ask a single clarifying question instead of guessing.
+ */
+export const CLARIFY_SYSTEM_PROMPT =
+  '你是「Open333」品牌的客服助手。客戶剛剛的訊息資訊不足，無法判斷他真正的問題。' +
+  '請參考前面的對話脈絡，用繁體中文禮貌地反問**一個**最關鍵的澄清問題以取得更多資訊。\n' +
+  '規則：\n' +
+  '1. 只問一個問題，不要連珠炮\n' +
+  '2. 問題要具體、可回答（避免「請問需要什麼幫助」這類空泛問句）\n' +
+  '3. 如果是家電問題，優先問：是哪個產品 / 故障狀況 / 型號\n' +
+  '4. 整體控制在 2 句話以內\n' +
+  '5. 不要編造或假設客戶的需求';
+
+type PromptKind = 'reply' | 'summarize';
+
+/**
+ * Generate a reply for a tenant. Uses tenant chat settings + system prompt.
+ *
+ * `promptKind` selects which system prompt to use:
+ *   - 'reply'     → tenant.chatSystemPrompt    (fallback CRM_REPLY_SYSTEM_PROMPT)
+ *   - 'summarize' → tenant.summarizeSystemPrompt (fallback SUMMARIZE_SYSTEM_PROMPT)
+ *
+ * `overrideSystemPrompt` lets callers (e.g. automation rules with custom
+ * prompts) inject their own prompt without touching tenant defaults.
+ */
+export async function generateReply(
+  prisma: PrismaClient,
+  tenantId: string,
+  userMessage: string,
+  kbContext = '',
+  options: {
+    promptKind?: PromptKind;
+    overrideSystemPrompt?: string;
+    history?: HistoryMessage[];
+  } = {},
+): Promise<string> {
+  const settings = await getChatSettings(prisma, tenantId);
+  const provider = getChatProvider(settings.provider);
+
+  const promptKind = options.promptKind ?? 'reply';
+  const systemPrompt =
+    options.overrideSystemPrompt ??
+    (promptKind === 'summarize'
+      ? settings.summarizeSystemPrompt || SUMMARIZE_SYSTEM_PROMPT
+      : settings.chatSystemPrompt || CRM_REPLY_SYSTEM_PROMPT);
+
+  return provider.generate({
+    systemPrompt,
+    userMessage,
+    kbContext,
+    history: options.history,
+    model: settings.model,
+    temperature: settings.temperature,
+    maxTokens: settings.maxTokens,
+    baseUrl: settings.baseUrl,
+  });
+}

--- a/apps/api/src/modules/ai/providers/gemini.provider.ts
+++ b/apps/api/src/modules/ai/providers/gemini.provider.ts
@@ -1,0 +1,150 @@
+import { getConfig } from '../../../config/env.js';
+import type {
+  ChatProvider,
+  ChatGenerateOptions,
+  ChatModelInfo,
+  ChatProviderHealth,
+} from './types.js';
+
+const GEMINI_BASE = 'https://generativelanguage.googleapis.com/v1beta';
+const TIMEOUT_MS = 120_000;
+
+// Curated whitelist — only models that make sense for CRM customer-service chat.
+// We display these in the dropdown by default; other models (TTS, image,
+// robotics, deep-research) are filtered out even if the API exposes them.
+const CURATED_CHAT_MODELS: { id: string; label: string; tier: ChatModelInfo['tier'] }[] = [
+  // Stable
+  { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash（推薦）', tier: 'stable' },
+  { id: 'gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash-Lite（最便宜）', tier: 'stable' },
+  { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro（最聰明）', tier: 'stable' },
+  { id: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash', tier: 'stable' },
+  { id: 'gemini-2.0-flash-lite', label: 'Gemini 2.0 Flash-Lite', tier: 'stable' },
+  // Latest aliases
+  { id: 'gemini-flash-latest', label: 'Gemini Flash (Latest)', tier: 'latest' },
+  { id: 'gemini-flash-lite-latest', label: 'Gemini Flash-Lite (Latest)', tier: 'latest' },
+  { id: 'gemini-pro-latest', label: 'Gemini Pro (Latest)', tier: 'latest' },
+  // Preview (unstable)
+  { id: 'gemini-3-pro-preview', label: 'Gemini 3 Pro Preview', tier: 'preview' },
+  { id: 'gemini-3-flash-preview', label: 'Gemini 3 Flash Preview', tier: 'preview' },
+];
+
+function getApiKey(): string {
+  const key = getConfig().GEMINI_API_KEY;
+  if (!key) throw new Error('GEMINI_API_KEY is not configured in environment');
+  return key;
+}
+
+export const GeminiChatProvider: ChatProvider = {
+  id: 'gemini',
+  label: 'Google Gemini',
+
+  async generate(opts: ChatGenerateOptions): Promise<string> {
+    const apiKey = getApiKey();
+    const url = `${GEMINI_BASE}/models/${encodeURIComponent(opts.model)}:generateContent`;
+
+    const fullSystemPrompt = opts.kbContext
+      ? `${opts.systemPrompt}\n\n以下是相關知識庫內容，請根據這些內容回答客戶問題：\n${opts.kbContext}`
+      : opts.systemPrompt;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+    try {
+      // Gemini uses role='user' | 'model' (NOT 'assistant'); convert history.
+      const contents = [
+        ...(opts.history ?? []).map((m) => ({
+          role: m.role === 'assistant' ? 'model' : 'user',
+          parts: [{ text: m.content }],
+        })),
+        { role: 'user', parts: [{ text: opts.userMessage }] },
+      ];
+
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-goog-api-key': apiKey,
+        },
+        body: JSON.stringify({
+          systemInstruction: { parts: [{ text: fullSystemPrompt }] },
+          contents,
+          generationConfig: {
+            temperature: opts.temperature,
+            maxOutputTokens: opts.maxTokens,
+          },
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const errBody = await response.text();
+        throw new Error(`Gemini generateContent failed (${response.status}): ${errBody}`);
+      }
+
+      const data = (await response.json()) as {
+        candidates?: { content?: { parts?: { text?: string }[] } }[];
+      };
+
+      const text = data.candidates?.[0]?.content?.parts
+        ?.map((p) => p.text ?? '')
+        .join('')
+        .trim();
+
+      if (!text) throw new Error('Gemini returned empty response');
+      return text;
+    } finally {
+      clearTimeout(timer);
+    }
+  },
+
+  async listModels(): Promise<ChatModelInfo[]> {
+    // We always return the curated list (UI dropdown); the live API call only
+    // serves as a key-validity check and is not used to drive UI options.
+    return CURATED_CHAT_MODELS.map((m) => ({ ...m }));
+  },
+
+  async health({ model }): Promise<ChatProviderHealth> {
+    let apiKey: string;
+    try {
+      apiKey = getApiKey();
+    } catch (err) {
+      return {
+        ok: false,
+        reachable: false,
+        modelInstalled: false,
+        currentModel: model,
+        error: (err as Error).message,
+      };
+    }
+
+    try {
+      const res = await fetch(`${GEMINI_BASE}/models/${encodeURIComponent(model)}`, {
+        headers: { 'x-goog-api-key': apiKey },
+      });
+      if (!res.ok) {
+        const body = await res.text();
+        return {
+          ok: false,
+          reachable: true,
+          modelInstalled: false,
+          currentModel: model,
+          error: `Gemini API ${res.status}: ${body.slice(0, 200)}`,
+        };
+      }
+      return {
+        ok: true,
+        reachable: true,
+        modelInstalled: true,
+        currentModel: model,
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        reachable: false,
+        modelInstalled: false,
+        currentModel: model,
+        error: `Cannot reach Gemini: ${(err as Error).message}`,
+      };
+    }
+  },
+};

--- a/apps/api/src/modules/ai/providers/index.ts
+++ b/apps/api/src/modules/ai/providers/index.ts
@@ -1,0 +1,26 @@
+import type { ChatProvider } from './types.js';
+import { OllamaChatProvider } from './ollama.provider.js';
+import { GeminiChatProvider } from './gemini.provider.js';
+
+export type {
+  ChatProvider,
+  ChatGenerateOptions,
+  ChatModelInfo,
+  ChatProviderHealth,
+  HistoryMessage,
+} from './types.js';
+
+const PROVIDERS: Record<string, ChatProvider> = {
+  ollama: OllamaChatProvider,
+  gemini: GeminiChatProvider,
+};
+
+export function getChatProvider(id: string): ChatProvider {
+  const p = PROVIDERS[id];
+  if (!p) throw new Error(`Unknown chat provider: ${id}`);
+  return p;
+}
+
+export function listChatProviders(): { id: string; label: string }[] {
+  return Object.values(PROVIDERS).map((p) => ({ id: p.id, label: p.label }));
+}

--- a/apps/api/src/modules/ai/providers/ollama.provider.ts
+++ b/apps/api/src/modules/ai/providers/ollama.provider.ts
@@ -1,0 +1,114 @@
+import type {
+  ChatProvider,
+  ChatGenerateOptions,
+  ChatModelInfo,
+  ChatProviderHealth,
+} from './types.js';
+
+const TIMEOUT_MS = 120_000;
+
+export const OllamaChatProvider: ChatProvider = {
+  id: 'ollama',
+  label: 'Ollama (local)',
+
+  async generate(opts: ChatGenerateOptions): Promise<string> {
+    const baseUrl = opts.baseUrl ?? 'http://localhost:11434';
+    const url = `${baseUrl}/api/chat`;
+
+    const fullSystemPrompt = opts.kbContext
+      ? `${opts.systemPrompt}\n\n以下是相關知識庫內容，請根據這些內容回答客戶問題：\n${opts.kbContext}`
+      : opts.systemPrompt;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+    try {
+      const messages: { role: 'system' | 'user' | 'assistant'; content: string }[] = [
+        { role: 'system', content: fullSystemPrompt },
+        ...(opts.history ?? []).map((m) => ({ role: m.role, content: m.content })),
+        { role: 'user', content: opts.userMessage },
+      ];
+
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: opts.model,
+          messages,
+          stream: false,
+          options: {
+            temperature: opts.temperature,
+            num_predict: opts.maxTokens,
+          },
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const errBody = await response.text();
+        throw new Error(`Ollama chat failed (${response.status}): ${errBody}`);
+      }
+
+      const data = (await response.json()) as { message?: { content: string } };
+      const text = data.message?.content?.trim();
+      if (!text) throw new Error('Ollama returned empty chat response');
+      return text;
+    } finally {
+      clearTimeout(timer);
+    }
+  },
+
+  async listModels({ baseUrl }): Promise<ChatModelInfo[]> {
+    const url = `${baseUrl ?? 'http://localhost:11434'}/api/tags`;
+    try {
+      const res = await fetch(url);
+      if (!res.ok) return [];
+      const data = (await res.json()) as { models?: { name: string; size?: number }[] };
+      return (data.models ?? []).map((m) => ({
+        id: m.name.replace(/:latest$/, ''),
+        label: m.name,
+        tier: 'stable' as const,
+      }));
+    } catch {
+      return [];
+    }
+  },
+
+  async health({ baseUrl, model }): Promise<ChatProviderHealth> {
+    const url = `${baseUrl ?? 'http://localhost:11434'}/api/tags`;
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        return {
+          ok: false,
+          reachable: false,
+          modelInstalled: false,
+          currentModel: model,
+          error: `Ollama responded ${res.status}`,
+        };
+      }
+      const data = (await res.json()) as { models?: { name: string }[] };
+      const models = data.models ?? [];
+      const installed = models.some(
+        (m) => m.name === model || m.name.startsWith(`${model}:`),
+      );
+      return {
+        ok: installed,
+        reachable: true,
+        modelInstalled: installed,
+        currentModel: model,
+        error: installed
+          ? undefined
+          : `Model "${model}" not installed locally. Available: ${models.map((m) => m.name).join(', ') || 'none'}`,
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        reachable: false,
+        modelInstalled: false,
+        currentModel: model,
+        error: `Cannot reach Ollama: ${(err as Error).message}`,
+      };
+    }
+  },
+};

--- a/apps/api/src/modules/ai/providers/types.ts
+++ b/apps/api/src/modules/ai/providers/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Chat Provider abstraction
+ *
+ * All chat providers (Ollama, Gemini, future: OpenAI/Anthropic) implement
+ * this interface. The provider is selected per-tenant via TenantSettings.chatProvider.
+ */
+
+export interface HistoryMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface ChatGenerateOptions {
+  systemPrompt: string;
+  /** Latest user turn (will be appended after history). */
+  userMessage: string;
+  kbContext?: string;
+  /** Prior conversation turns (oldest → newest), excluding the current userMessage. */
+  history?: HistoryMessage[];
+  model: string;
+  temperature: number;
+  maxTokens: number;
+  // Provider-specific connection (Ollama needs baseUrl; Gemini reads global API key)
+  baseUrl?: string;
+}
+
+export interface ChatProvider {
+  readonly id: 'ollama' | 'gemini';
+  readonly label: string;
+
+  /** Generate a reply. Throws on failure. */
+  generate(opts: ChatGenerateOptions): Promise<string>;
+
+  /** List available chat-capable models. Returns [] on failure. */
+  listModels(opts: { baseUrl?: string }): Promise<ChatModelInfo[]>;
+
+  /** Quick health check — does this provider currently work? */
+  health(opts: { baseUrl?: string; model: string }): Promise<ChatProviderHealth>;
+}
+
+export interface ChatModelInfo {
+  id: string;
+  label: string;
+  // Optional metadata for display
+  inputTokenLimit?: number;
+  outputTokenLimit?: number;
+  tier?: 'stable' | 'latest' | 'preview' | 'open-source';
+}
+
+export interface ChatProviderHealth {
+  ok: boolean;
+  reachable: boolean;
+  modelInstalled: boolean;
+  currentModel: string;
+  error?: string;
+}

--- a/apps/api/src/modules/ai/sentiment.service.ts
+++ b/apps/api/src/modules/ai/sentiment.service.ts
@@ -1,7 +1,8 @@
 /**
- * Sentiment Analysis Service — uses Ollama LLM to analyze message sentiment.
+ * Sentiment Analysis Service — uses tenant-configured LLM to analyze message sentiment.
  */
 
+import type { PrismaClient } from '@prisma/client';
 import { generateReply } from './llm.service.js';
 import { logger } from '@open333crm/core';
 
@@ -44,9 +45,15 @@ function keywordFallback(text: string): SentimentResult {
   return { sentiment: 'neutral', score: 0, confidence: 0.4 };
 }
 
-export async function analyzeSentiment(text: string): Promise<SentimentResult> {
+export async function analyzeSentiment(
+  prisma: PrismaClient,
+  tenantId: string,
+  text: string,
+): Promise<SentimentResult> {
   try {
-    const raw = await generateReply(SENTIMENT_SYSTEM_PROMPT, text, '');
+    const raw = await generateReply(prisma, tenantId, text, '', {
+      overrideSystemPrompt: SENTIMENT_SYSTEM_PROMPT,
+    });
 
     // Try to parse JSON from LLM response
     const jsonMatch = raw.match(/\{[\s\S]*?\}/);

--- a/apps/api/src/modules/automation/automation.worker.ts
+++ b/apps/api/src/modules/automation/automation.worker.ts
@@ -283,7 +283,7 @@ export function setupAutomationWorker(prisma: PrismaClient, io: Server) {
       // Sentiment analysis on inbound messages
       if (text && messageId) {
         try {
-          const sentimentResult = await analyzeSentiment(text);
+          const sentimentResult = await analyzeSentiment(prisma, event.tenantId, text);
           // Update message metadata with sentiment result
           const existingMessage = await prisma.message.findUnique({
             where: { id: messageId },
@@ -398,7 +398,7 @@ export function setupAutomationWorker(prisma: PrismaClient, io: Server) {
           });
           const messageText = (latestMessage?.content as Record<string, unknown>)?.text as string | undefined;
           if (messageText) {
-            const classification = await classifyIssue(messageText);
+            const classification = await classifyIssue(prisma, event.tenantId, messageText);
             await prisma.case.update({
               where: { id: caseId },
               data: { category: classification.category },

--- a/apps/api/src/modules/automation/engine/action-executor.ts
+++ b/apps/api/src/modules/automation/engine/action-executor.ts
@@ -20,7 +20,7 @@ import type { PrismaClient } from '@prisma/client';
 import type { Server } from 'socket.io';
 import { attemptKbAutoReply } from '../../ai/kb-autoreply.service.js';
 import { deliverToChannel } from '../../conversation/conversation.service.js';
-import { generateReply, CRM_REPLY_SYSTEM_PROMPT } from '../../ai/llm.service.js';
+import { generateReply } from '../../ai/llm.service.js';
 import { autoAssignCase } from '../../case/assignment.service.js';
 import { logger } from '@open333crm/core';
 
@@ -614,15 +614,21 @@ async function handleLlmReply(
     })
     .join('\n');
 
-  // Use custom system prompt if provided, otherwise default
-  // Always append Traditional Chinese enforcement
-  const basePrompt = (params.systemPrompt as string) || CRM_REPLY_SYSTEM_PROMPT;
-  const systemPrompt = basePrompt.includes('繁體中文')
-    ? basePrompt
-    : basePrompt + ' 你必須全程使用繁體中文回覆。';
+  // If the rule overrides the system prompt, use it; otherwise fall back to
+  // tenant chat settings (which already default to CRM_REPLY_SYSTEM_PROMPT
+  // when not customized). Always append Traditional Chinese enforcement.
+  const customPrompt = params.systemPrompt as string | undefined;
+  let overrideSystemPrompt: string | undefined;
+  if (customPrompt) {
+    overrideSystemPrompt = customPrompt.includes('繁體中文')
+      ? customPrompt
+      : customPrompt + ' 你必須全程使用繁體中文回覆。';
+  }
 
-  // Generate reply using LLM
-  const replyText = await generateReply(systemPrompt, history, '');
+  // Generate reply using LLM (per-tenant provider/model/prompt)
+  const replyText = await generateReply(prisma, context.tenantId, history, '', {
+    overrideSystemPrompt,
+  });
 
   // Save as BOT message
   const message = await prisma.message.create({

--- a/apps/api/src/modules/embedding/embedding.service.ts
+++ b/apps/api/src/modules/embedding/embedding.service.ts
@@ -1,11 +1,14 @@
 /**
  * Embedding service — generates embeddings via Ollama BGE-M3
  * and performs vector similarity search using pgvector.
+ *
+ * Configuration is now per-tenant (TenantSettings.embeddingBaseUrl/Model).
+ * Callers must pass tenantId so we can load the right Ollama target/model.
  */
 
 import type { PrismaClient } from '@prisma/client';
-import { getConfig } from '../../config/env.js';
 import { logger } from '@open333crm/core';
+import { getEmbeddingSettings } from '../settings/embedding-settings.service.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -26,15 +29,19 @@ interface SearchOptions {
 
 // ─── Embedding Generation ───────────────────────────────────────────────────
 
-export async function generateEmbedding(text: string): Promise<number[]> {
-  const config = getConfig();
-  const url = `${config.OLLAMA_BASE_URL}/api/embed`;
+export async function generateEmbedding(
+  prisma: PrismaClient,
+  tenantId: string,
+  text: string,
+): Promise<number[]> {
+  const settings = await getEmbeddingSettings(prisma, tenantId);
+  const url = `${settings.baseUrl}/api/embed`;
 
   const response = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      model: config.OLLAMA_EMBED_MODEL,
+      model: settings.model,
       input: text,
     }),
   });
@@ -60,13 +67,19 @@ export function prepareArticleText(article: {
   tags: string[];
   summary: string;
   content: string;
+  spec?: unknown;
+  attachments?: { filename: string }[];
 }): string {
   const parts = [
     `標題: ${article.title}`,
     `分類: ${article.category}`,
     article.tags.length > 0 ? `標籤: ${article.tags.join(', ')}` : '',
+    article.spec ? `規格: ${JSON.stringify(article.spec)}` : '',
     `摘要: ${article.summary}`,
     `內容: ${article.content}`,
+    article.attachments && article.attachments.length > 0
+      ? `附件: ${article.attachments.map((a) => a.filename).join(', ')}`
+      : '',
   ].filter(Boolean);
 
   const combined = parts.join('\n');
@@ -82,7 +95,8 @@ export async function searchSimilarArticles(
   tenantId: string,
   options: SearchOptions = {},
 ): Promise<ArticleSearchResult[]> {
-  const { topK = 5, threshold = 0.3 } = options;
+  const settings = await getEmbeddingSettings(prisma, tenantId);
+  const { topK = settings.topK, threshold = settings.threshold } = options;
 
   const vectorStr = `[${queryEmbedding.join(',')}]`;
 
@@ -123,7 +137,16 @@ export async function embedArticle(
 ): Promise<void> {
   const article = await prisma.kmArticle.findUnique({
     where: { id: articleId },
-    select: { title: true, category: true, tags: true, summary: true, content: true },
+    select: {
+      tenantId: true,
+      title: true,
+      category: true,
+      tags: true,
+      summary: true,
+      content: true,
+      spec: true,
+      attachments: { select: { filename: true } },
+    },
   });
 
   if (!article) {
@@ -131,14 +154,14 @@ export async function embedArticle(
   }
 
   const text = prepareArticleText(article);
-  const embedding = await generateEmbedding(text);
+  const embedding = await generateEmbedding(prisma, article.tenantId, text);
   const vectorStr = `[${embedding.join(',')}]`;
-  const config = getConfig();
+  const settings = await getEmbeddingSettings(prisma, article.tenantId);
 
   await prisma.$executeRawUnsafe(
     `UPDATE km_articles SET embedding = $1::vector, "embeddingModel" = $2 WHERE id = $3::uuid`,
     vectorStr,
-    config.OLLAMA_EMBED_MODEL,
+    settings.model,
     articleId,
   );
 }
@@ -151,23 +174,32 @@ export async function bulkReembed(
 ): Promise<{ total: number; succeeded: number; failed: number }> {
   const articles = await prisma.kmArticle.findMany({
     where: { tenantId, status: 'PUBLISHED' },
-    select: { id: true, title: true, category: true, tags: true, summary: true, content: true },
+    select: {
+      id: true,
+      title: true,
+      category: true,
+      tags: true,
+      summary: true,
+      content: true,
+      spec: true,
+      attachments: { select: { filename: true } },
+    },
   });
 
   let succeeded = 0;
   let failed = 0;
-  const config = getConfig();
+  const settings = await getEmbeddingSettings(prisma, tenantId);
 
   for (const article of articles) {
     try {
       const text = prepareArticleText(article);
-      const embedding = await generateEmbedding(text);
+      const embedding = await generateEmbedding(prisma, tenantId, text);
       const vectorStr = `[${embedding.join(',')}]`;
 
       await prisma.$executeRawUnsafe(
         `UPDATE km_articles SET embedding = $1::vector, "embeddingModel" = $2 WHERE id = $3::uuid`,
         vectorStr,
-        config.OLLAMA_EMBED_MODEL,
+        settings.model,
         article.id,
       );
       succeeded++;
@@ -182,15 +214,18 @@ export async function bulkReembed(
 
 // ─── Health Check ───────────────────────────────────────────────────────────
 
-export async function checkOllamaHealth(): Promise<{
+export async function checkOllamaHealth(
+  prisma: PrismaClient,
+  tenantId: string,
+): Promise<{
   ok: boolean;
   model?: string;
   error?: string;
 }> {
-  const config = getConfig();
+  const settings = await getEmbeddingSettings(prisma, tenantId);
 
   try {
-    const response = await fetch(`${config.OLLAMA_BASE_URL}/api/tags`);
+    const response = await fetch(`${settings.baseUrl}/api/tags`);
     if (!response.ok) {
       return { ok: false, error: `Ollama returned ${response.status}` };
     }
@@ -201,13 +236,13 @@ export async function checkOllamaHealth(): Promise<{
 
     const models = data.models || [];
     const found = models.find(
-      (m) => m.name === config.OLLAMA_EMBED_MODEL || m.name.startsWith(`${config.OLLAMA_EMBED_MODEL}:`),
+      (m) => m.name === settings.model || m.name.startsWith(`${settings.model}:`),
     );
 
     if (!found) {
       return {
         ok: false,
-        error: `Model "${config.OLLAMA_EMBED_MODEL}" not found. Available: ${models.map((m) => m.name).join(', ') || 'none'}`,
+        error: `Model "${settings.model}" not found. Available: ${models.map((m) => m.name).join(', ') || 'none'}`,
       };
     }
 

--- a/apps/api/src/modules/knowledge/knowledge.routes.ts
+++ b/apps/api/src/modules/knowledge/knowledge.routes.ts
@@ -16,6 +16,11 @@ import {
   embedArticle,
 } from './knowledge.service.js';
 import { parseFileToMarkdown } from './file-parser.service.js';
+import {
+  ingestPartnerDoc,
+  type PartnerAttachmentInput,
+} from './partner-ingest.service.js';
+import { requireSupervisor } from '../../guards/rbac.guard.js';
 import { success, paginated } from '../../shared/utils/response.js';
 
 const createArticleSchema = z.object({
@@ -134,6 +139,75 @@ export default async function knowledgeRoutes(fastify: FastifyInstance) {
     return reply.send(success({ uploaded, failed, results }));
   });
 
+  // POST /api/v1/knowledge/partner-ingest — 合作方單筆推送 (multipart/form-data)
+  // Fields: DocID, Ver, VerCreatTime, AI_Q, AI_A, Source/Soruce, Spec, IsAttached
+  // Files:  Attached (可多檔)
+  fastify.post(
+    '/partner-ingest',
+    { preHandler: [requireSupervisor()] },
+    async (request, reply) => {
+      const fields: Record<string, string> = {};
+      const attachments: PartnerAttachmentInput[] = [];
+
+      for await (const part of request.parts()) {
+        if (part.type === 'file') {
+          if (part.fieldname === 'Attached') {
+            const buffer = await part.toBuffer();
+            attachments.push({
+              buffer,
+              filename: part.filename,
+              mimeType: part.mimetype,
+            });
+          } else {
+            // Drain unrelated file fields so the stream doesn't hang
+            await part.toBuffer();
+          }
+        } else {
+          fields[part.fieldname] = String(part.value);
+        }
+      }
+
+      const docId = fields.DocID ?? '';
+      if (!docId) {
+        return reply.status(400).send({
+          success: false,
+          error: { code: 'BAD_REQUEST', message: 'DocID is required' },
+        });
+      }
+
+      // Tolerate Stanley's typo: accept both Source and Soruce
+      const source = fields.Source ?? fields.Soruce ?? '';
+
+      try {
+        const result = await ingestPartnerDoc(
+          fastify.prisma,
+          request.agent.tenantId,
+          request.agent.id,
+          {
+            docId,
+            ver: Number(fields.Ver) || 0,
+            verCreatTime: fields.VerCreatTime ?? '',
+            aiQ: fields.AI_Q ?? '',
+            aiA: fields.AI_A ?? '',
+            source,
+            spec: fields.Spec,
+            isAttached: fields.IsAttached === 'true',
+            attachments,
+          },
+        );
+        return reply.send(success(result));
+      } catch (err) {
+        return reply.status(500).send({
+          success: false,
+          error: {
+            code: 'INGEST_FAILED',
+            message: (err as Error).message,
+          },
+        });
+      }
+    },
+  );
+
   // POST /api/v1/knowledge/bulk-embed — 重新向量化所有已發布文章
   fastify.post('/bulk-embed', async (request, reply) => {
     const result = await bulkReembed(fastify.prisma, request.agent.tenantId);
@@ -141,8 +215,8 @@ export default async function knowledgeRoutes(fastify: FastifyInstance) {
   });
 
   // GET /api/v1/knowledge/embedding-status — 嵌入服務健康檢查
-  fastify.get('/embedding-status', async (_request, reply) => {
-    const status = await checkOllamaHealth();
+  fastify.get('/embedding-status', async (request, reply) => {
+    const status = await checkOllamaHealth(fastify.prisma, request.agent.tenantId);
     return reply.send(success(status));
   });
 

--- a/apps/api/src/modules/knowledge/knowledge.service.ts
+++ b/apps/api/src/modules/knowledge/knowledge.service.ts
@@ -54,6 +54,10 @@ export async function listArticles(
         createdById: true,
         createdAt: true,
         updatedAt: true,
+        externalDocId: true,
+        externalVer: true,
+        externalSource: true,
+        _count: { select: { attachments: true } },
       },
     }),
     prisma.kmArticle.count({ where: where as any }),
@@ -80,6 +84,19 @@ export async function listArticles(
 export async function getArticle(prisma: PrismaClient, id: string, tenantId: string) {
   const article = await prisma.kmArticle.findFirst({
     where: { id, tenantId },
+    include: {
+      attachments: {
+        select: {
+          id: true,
+          filename: true,
+          url: true,
+          mimeType: true,
+          sizeBytes: true,
+          createdAt: true,
+        },
+        orderBy: { createdAt: 'asc' },
+      },
+    },
   });
 
   if (!article) {
@@ -259,7 +276,7 @@ export async function semanticSearch(
   query: string,
   options: { topK?: number; threshold?: number } = {},
 ) {
-  const queryEmbedding = await generateEmbedding(query);
+  const queryEmbedding = await generateEmbedding(prisma, tenantId, query);
   const results = await searchSimilarArticles(prisma, queryEmbedding, tenantId, options);
   return results;
 }

--- a/apps/api/src/modules/knowledge/partner-ingest.service.ts
+++ b/apps/api/src/modules/knowledge/partner-ingest.service.ts
@@ -1,0 +1,199 @@
+/**
+ * Partner Ingest Service
+ *
+ * Receives one document at a time from a partner system (e.g. Stanley's
+ * "Chatbot" feeder) via HTTP multipart and upserts it into KmArticle.
+ *
+ * Versioning is governed by `Ver`:
+ *   - new DocID         → create
+ *   - existing, newer   → update + replace attachments + re-embed
+ *   - existing, same/old → skip (idempotent retries)
+ */
+
+import type { PrismaClient, Prisma } from '@prisma/client';
+import { uploadFile } from '../storage/storage.service.js';
+import { embedArticle } from '../embedding/embedding.service.js';
+import { logger } from '@open333crm/core';
+
+export interface PartnerAttachmentInput {
+  buffer: Buffer;
+  filename: string;
+  mimeType: string;
+}
+
+export interface PartnerDocInput {
+  docId: string;
+  ver: number;
+  verCreatTime: string;
+  aiQ: string;
+  aiA: string;
+  source: string;
+  spec?: string;
+  isAttached: boolean;
+  attachments: PartnerAttachmentInput[];
+}
+
+export interface PartnerIngestResult {
+  status: 'created' | 'updated' | 'skipped';
+  reason?: string;
+  articleId: string;
+  externalDocId: string;
+  externalVer: number;
+  attachmentsLinked: number;
+}
+
+const MS_DATE_RE = /\/Date\((\d+)\)\//;
+
+function parseVerCreatTime(input: string): Date | null {
+  const m = input.match(MS_DATE_RE);
+  if (!m) return null;
+  const ms = Number(m[1]);
+  if (!Number.isFinite(ms)) return null;
+  return new Date(ms);
+}
+
+function parseSpec(raw?: string): { spec: Prisma.InputJsonValue | undefined; specRaw?: string } {
+  if (!raw) return { spec: undefined };
+  try {
+    const parsed = JSON.parse(raw);
+    return { spec: parsed as Prisma.InputJsonValue };
+  } catch {
+    return { spec: undefined, specRaw: raw };
+  }
+}
+
+function deriveSummary(content: string, max = 200): string {
+  const trimmed = content.replace(/\s+/g, ' ').trim();
+  return trimmed.length > max ? `${trimmed.slice(0, max)}…` : trimmed;
+}
+
+export async function ingestPartnerDoc(
+  prisma: PrismaClient,
+  tenantId: string,
+  agentId: string,
+  input: PartnerDocInput,
+): Promise<PartnerIngestResult> {
+  if (!input.docId) {
+    throw new Error('DocID is required');
+  }
+
+  const { spec, specRaw } = parseSpec(input.spec);
+  const importedAt = parseVerCreatTime(input.verCreatTime);
+
+  // 1. Look up existing article by (tenantId, externalDocId)
+  const existing = await prisma.kmArticle.findUnique({
+    where: { tenantId_externalDocId: { tenantId, externalDocId: input.docId } },
+    select: { id: true, externalVer: true },
+  });
+
+  // 2. Skip if not newer
+  if (existing && input.ver <= existing.externalVer) {
+    return {
+      status: 'skipped',
+      reason: `incoming ver ${input.ver} ≤ existing ver ${existing.externalVer}`,
+      articleId: existing.id,
+      externalDocId: input.docId,
+      externalVer: existing.externalVer,
+      attachmentsLinked: 0,
+    };
+  }
+
+  // 3. Build common data payload
+  const summary = deriveSummary(input.aiA);
+  const metadataExtras: Record<string, unknown> = {};
+  if (specRaw) metadataExtras.specRaw = specRaw;
+
+  const dataCommon = {
+    title: input.aiQ || `(DocID ${input.docId})`,
+    content: input.aiA,
+    summary,
+    category: input.source || '',
+    tags: [] as string[],
+    status: 'PUBLISHED' as const,
+    externalDocId: input.docId,
+    externalVer: input.ver,
+    externalSource: input.source,
+    spec: spec as Prisma.InputJsonValue | undefined,
+    importedAt,
+    metadata: Object.keys(metadataExtras).length > 0
+      ? (metadataExtras as Prisma.InputJsonValue)
+      : undefined,
+  };
+
+  let articleId: string;
+  let status: 'created' | 'updated';
+
+  if (existing) {
+    // 4a. Update existing + delete old attachments (cascade replacement)
+    await prisma.kmArticleAttachment.deleteMany({ where: { articleId: existing.id } });
+    await prisma.kmArticle.update({
+      where: { id: existing.id },
+      data: dataCommon,
+    });
+    articleId = existing.id;
+    status = 'updated';
+  } else {
+    // 4b. Create new
+    const created = await prisma.kmArticle.create({
+      data: {
+        tenantId,
+        createdById: agentId,
+        ...dataCommon,
+      },
+      select: { id: true },
+    });
+    articleId = created.id;
+    status = 'created';
+  }
+
+  // 5. Upload attachments + create attachment rows
+  let attachmentsLinked = 0;
+  if (input.isAttached && input.attachments.length > 0) {
+    for (const att of input.attachments) {
+      try {
+        const { key, url } = await uploadFile(
+          att.buffer,
+          att.filename,
+          att.mimeType,
+          tenantId,
+          'media',
+          `kb/${input.docId}`,
+        );
+        await prisma.kmArticleAttachment.create({
+          data: {
+            articleId,
+            filename: att.filename,
+            storageKey: key,
+            url,
+            mimeType: att.mimeType,
+            sizeBytes: att.buffer.length,
+          },
+        });
+        attachmentsLinked++;
+      } catch (err) {
+        logger.error(
+          `[PartnerIngest] Failed to upload attachment "${att.filename}" for DocID ${input.docId}: ${(err as Error).message}`,
+        );
+      }
+    }
+  }
+
+  // 6. Fire-and-forget re-embedding (so KB search reflects the latest content)
+  embedArticle(prisma, articleId).catch((err) => {
+    logger.error(
+      `[PartnerIngest] Embedding failed for article ${articleId} (DocID ${input.docId}): ${(err as Error).message}`,
+    );
+  });
+
+  logger.info(
+    `[PartnerIngest] ${status} DocID=${input.docId} ver=${input.ver} attachments=${attachmentsLinked}`,
+  );
+
+  return {
+    status,
+    articleId,
+    externalDocId: input.docId,
+    externalVer: input.ver,
+    attachmentsLinked,
+  };
+}

--- a/apps/api/src/modules/settings/chat-settings.service.ts
+++ b/apps/api/src/modules/settings/chat-settings.service.ts
@@ -1,0 +1,122 @@
+/**
+ * Chat Settings Service
+ *
+ * Per-tenant chat / RAG configuration: provider, model, generation params,
+ * and system prompts. Used by llm.service.ts and ai.service.ts.
+ */
+
+import type { PrismaClient } from '@prisma/client';
+import { getChatProvider, listChatProviders } from '../ai/providers/index.js';
+import type { ChatModelInfo, ChatProviderHealth } from '../ai/providers/index.js';
+
+export interface ChatSettings {
+  provider: 'ollama' | 'gemini';
+  model: string;
+  baseUrl: string;
+  temperature: number;
+  maxTokens: number;
+  chatSystemPrompt: string;
+  summarizeSystemPrompt: string;
+  clarifySystemPrompt: string;
+  clarifyThreshold: number;
+  clarifyMaxAttempts: number;
+}
+
+export const DEFAULT_CHAT_SETTINGS: ChatSettings = {
+  provider: 'ollama',
+  model: 'qwen2.5:3b',
+  baseUrl: 'http://localhost:11434',
+  temperature: 0.3,
+  maxTokens: 500,
+  chatSystemPrompt: '',
+  summarizeSystemPrompt: '',
+  clarifySystemPrompt: '',
+  clarifyThreshold: 0.5,
+  clarifyMaxAttempts: 2,
+};
+
+export async function getChatSettings(
+  prisma: PrismaClient,
+  tenantId: string,
+): Promise<ChatSettings> {
+  let s = await prisma.tenantSettings.findUnique({ where: { tenantId } });
+  if (!s) {
+    s = await prisma.tenantSettings.create({ data: { tenantId } });
+  }
+  return {
+    provider: (s.chatProvider as ChatSettings['provider']) ?? DEFAULT_CHAT_SETTINGS.provider,
+    model: s.chatModel,
+    baseUrl: s.chatBaseUrl,
+    temperature: s.chatTemperature,
+    maxTokens: s.chatMaxTokens,
+    chatSystemPrompt: s.chatSystemPrompt,
+    summarizeSystemPrompt: s.summarizeSystemPrompt,
+    clarifySystemPrompt: s.clarifySystemPrompt,
+    clarifyThreshold: s.clarifyThreshold,
+    clarifyMaxAttempts: s.clarifyMaxAttempts,
+  };
+}
+
+export async function updateChatSettings(
+  prisma: PrismaClient,
+  tenantId: string,
+  patch: Partial<ChatSettings>,
+): Promise<{ settings: ChatSettings; providerChanged: boolean; previousProvider: string }> {
+  const current = await getChatSettings(prisma, tenantId);
+  const next: ChatSettings = { ...current, ...patch };
+  const providerChanged = patch.provider !== undefined && patch.provider !== current.provider;
+
+  const updated = await prisma.tenantSettings.update({
+    where: { tenantId },
+    data: {
+      chatProvider: next.provider,
+      chatModel: next.model,
+      chatBaseUrl: next.baseUrl,
+      chatTemperature: next.temperature,
+      chatMaxTokens: next.maxTokens,
+      chatSystemPrompt: next.chatSystemPrompt,
+      summarizeSystemPrompt: next.summarizeSystemPrompt,
+      clarifySystemPrompt: next.clarifySystemPrompt,
+      clarifyThreshold: next.clarifyThreshold,
+      clarifyMaxAttempts: next.clarifyMaxAttempts,
+    },
+  });
+
+  return {
+    settings: {
+      provider: updated.chatProvider as ChatSettings['provider'],
+      model: updated.chatModel,
+      baseUrl: updated.chatBaseUrl,
+      temperature: updated.chatTemperature,
+      maxTokens: updated.chatMaxTokens,
+      chatSystemPrompt: updated.chatSystemPrompt,
+      summarizeSystemPrompt: updated.summarizeSystemPrompt,
+      clarifySystemPrompt: updated.clarifySystemPrompt,
+      clarifyThreshold: updated.clarifyThreshold,
+      clarifyMaxAttempts: updated.clarifyMaxAttempts,
+    },
+    providerChanged,
+    previousProvider: current.provider,
+  };
+}
+
+export async function listChatModels(
+  providerId: string,
+  baseUrl?: string,
+): Promise<ChatModelInfo[]> {
+  const provider = getChatProvider(providerId);
+  return provider.listModels({ baseUrl });
+}
+
+export async function checkChatHealth(
+  providerId: string,
+  model: string,
+  baseUrl?: string,
+): Promise<ChatProviderHealth> {
+  const provider = getChatProvider(providerId);
+  return provider.health({ baseUrl, model });
+}
+
+export function getProviderList(): { id: string; label: string }[] {
+  return listChatProviders();
+}

--- a/apps/api/src/modules/settings/embedding-settings.service.ts
+++ b/apps/api/src/modules/settings/embedding-settings.service.ts
@@ -1,0 +1,185 @@
+/**
+ * Embedding Settings Service
+ *
+ * Manages tenant-scoped embedding configuration (Ollama base URL, model,
+ * search topK/threshold). Replaces global env-based config so each tenant
+ * can tune its own retrieval behavior.
+ *
+ * Vector dimension is locked at 1024 (matches schema.prisma vector(1024) +
+ * existing pgvector indexes). Switching to a model with a different
+ * dimension is unsupported and would corrupt existing embeddings.
+ */
+
+import type { PrismaClient } from '@prisma/client';
+import { logger } from '@open333crm/core';
+
+export interface EmbeddingSettings {
+  baseUrl: string;
+  model: string;
+  topK: number;
+  threshold: number;
+}
+
+export interface OllamaModel {
+  name: string;
+  size?: number;
+  modified_at?: string;
+}
+
+export interface OllamaHealth {
+  ok: boolean;
+  reachable: boolean;
+  modelInstalled: boolean;
+  currentModel: string;
+  error?: string;
+}
+
+export interface EmbeddingStats {
+  total: number;
+  embedded: number;
+  missing: number;
+}
+
+export const DEFAULT_EMBEDDING_SETTINGS: EmbeddingSettings = {
+  baseUrl: 'http://localhost:11434',
+  model: 'bge-m3',
+  topK: 5,
+  threshold: 0.3,
+};
+
+// Vector dimension is hard-coded in the DB schema; keep this in sync if you
+// ever migrate to a different size.
+export const EMBEDDING_VECTOR_DIM = 1024;
+
+// ─── Settings CRUD ──────────────────────────────────────────────────────────
+
+export async function getEmbeddingSettings(
+  prisma: PrismaClient,
+  tenantId: string,
+): Promise<EmbeddingSettings> {
+  let settings = await prisma.tenantSettings.findUnique({ where: { tenantId } });
+
+  if (!settings) {
+    settings = await prisma.tenantSettings.create({
+      data: {
+        tenantId,
+        embeddingBaseUrl: DEFAULT_EMBEDDING_SETTINGS.baseUrl,
+        embeddingModel: DEFAULT_EMBEDDING_SETTINGS.model,
+        embeddingTopK: DEFAULT_EMBEDDING_SETTINGS.topK,
+        embeddingThreshold: DEFAULT_EMBEDDING_SETTINGS.threshold,
+      },
+    });
+  }
+
+  return {
+    baseUrl: settings.embeddingBaseUrl,
+    model: settings.embeddingModel,
+    topK: settings.embeddingTopK,
+    threshold: settings.embeddingThreshold,
+  };
+}
+
+export async function updateEmbeddingSettings(
+  prisma: PrismaClient,
+  tenantId: string,
+  patch: Partial<EmbeddingSettings>,
+): Promise<{ settings: EmbeddingSettings; modelChanged: boolean; previousModel: string }> {
+  const current = await getEmbeddingSettings(prisma, tenantId);
+  const next: EmbeddingSettings = { ...current, ...patch };
+  const modelChanged = patch.model !== undefined && patch.model !== current.model;
+
+  const updated = await prisma.tenantSettings.update({
+    where: { tenantId },
+    data: {
+      embeddingBaseUrl: next.baseUrl,
+      embeddingModel: next.model,
+      embeddingTopK: next.topK,
+      embeddingThreshold: next.threshold,
+    },
+  });
+
+  return {
+    settings: {
+      baseUrl: updated.embeddingBaseUrl,
+      model: updated.embeddingModel,
+      topK: updated.embeddingTopK,
+      threshold: updated.embeddingThreshold,
+    },
+    modelChanged,
+    previousModel: current.model,
+  };
+}
+
+// ─── Ollama Probing ─────────────────────────────────────────────────────────
+
+export async function listOllamaModels(baseUrl: string): Promise<OllamaModel[]> {
+  try {
+    const response = await fetch(`${baseUrl}/api/tags`);
+    if (!response.ok) return [];
+    const data = (await response.json()) as { models?: OllamaModel[] };
+    return data.models ?? [];
+  } catch (err) {
+    logger.warn(`[EmbeddingSettings] Failed to list Ollama models from ${baseUrl}: ${(err as Error).message}`);
+    return [];
+  }
+}
+
+export async function checkOllamaHealth(
+  baseUrl: string,
+  model: string,
+): Promise<OllamaHealth> {
+  try {
+    const response = await fetch(`${baseUrl}/api/tags`);
+    if (!response.ok) {
+      return {
+        ok: false,
+        reachable: false,
+        modelInstalled: false,
+        currentModel: model,
+        error: `Ollama responded ${response.status}`,
+      };
+    }
+
+    const data = (await response.json()) as { models?: OllamaModel[] };
+    const models = data.models ?? [];
+    const installed = models.some((m) => m.name === model || m.name.startsWith(`${model}:`));
+
+    return {
+      ok: installed,
+      reachable: true,
+      modelInstalled: installed,
+      currentModel: model,
+      error: installed
+        ? undefined
+        : `Model "${model}" not installed. Available: ${models.map((m) => m.name).join(', ') || 'none'}`,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      reachable: false,
+      modelInstalled: false,
+      currentModel: model,
+      error: `Cannot reach Ollama at ${baseUrl}: ${(err as Error).message}`,
+    };
+  }
+}
+
+// ─── Stats ──────────────────────────────────────────────────────────────────
+
+export async function getEmbeddingStats(
+  prisma: PrismaClient,
+  tenantId: string,
+): Promise<EmbeddingStats> {
+  const total = await prisma.kmArticle.count({
+    where: { tenantId, status: 'PUBLISHED' },
+  });
+
+  const embeddedRows = await prisma.$queryRawUnsafe<{ count: bigint }[]>(
+    `SELECT COUNT(*)::bigint AS count FROM km_articles
+     WHERE "tenantId" = $1::uuid AND status = 'PUBLISHED' AND embedding IS NOT NULL`,
+    tenantId,
+  );
+  const embedded = Number(embeddedRows[0]?.count ?? 0);
+
+  return { total, embedded, missing: total - embedded };
+}

--- a/apps/api/src/modules/settings/settings.routes.ts
+++ b/apps/api/src/modules/settings/settings.routes.ts
@@ -2,6 +2,26 @@ import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { success } from '../../shared/utils/response.js';
 import { getOfficeHours, updateOfficeHours } from './office-hours.service.js';
+import {
+  getEmbeddingSettings,
+  updateEmbeddingSettings,
+  checkOllamaHealth,
+  listOllamaModels,
+  getEmbeddingStats,
+  EMBEDDING_VECTOR_DIM,
+} from './embedding-settings.service.js';
+import {
+  getChatSettings,
+  updateChatSettings,
+  listChatModels,
+  checkChatHealth,
+  getProviderList,
+} from './chat-settings.service.js';
+import {
+  CRM_REPLY_SYSTEM_PROMPT,
+  SUMMARIZE_SYSTEM_PROMPT,
+  CLARIFY_SYSTEM_PROMPT,
+} from '../ai/llm.service.js';
 import { requireSupervisor } from '../../guards/rbac.guard.js';
 
 const dayScheduleSchema = z.object({
@@ -48,4 +68,117 @@ export default async function settingsRoutes(fastify: FastifyInstance) {
     );
     return reply.send(success(result));
   });
+
+  // ─── Embedding Settings ──────────────────────────────────────────────────
+  // GET /api/v1/settings/embedding — settings + Ollama health + models + stats
+  fastify.get('/embedding', async (request, reply) => {
+    const tenantId = request.agent.tenantId;
+    const settings = await getEmbeddingSettings(fastify.prisma, tenantId);
+    const [health, models, stats] = await Promise.all([
+      checkOllamaHealth(settings.baseUrl, settings.model),
+      listOllamaModels(settings.baseUrl),
+      getEmbeddingStats(fastify.prisma, tenantId),
+    ]);
+    return reply.send(
+      success({
+        settings,
+        health,
+        models,
+        stats,
+        vectorDim: EMBEDDING_VECTOR_DIM,
+      }),
+    );
+  });
+
+  // PUT /api/v1/settings/embedding — update settings (returns modelChanged hint)
+  fastify.put('/embedding', async (request, reply) => {
+    const patch = embeddingSettingsSchema.parse(request.body);
+    const result = await updateEmbeddingSettings(
+      fastify.prisma,
+      request.agent.tenantId,
+      patch,
+    );
+    return reply.send(success(result));
+  });
+
+  // POST /api/v1/settings/embedding/health — re-check health on demand
+  fastify.post('/embedding/health', async (request, reply) => {
+    const settings = await getEmbeddingSettings(fastify.prisma, request.agent.tenantId);
+    const health = await checkOllamaHealth(settings.baseUrl, settings.model);
+    return reply.send(success(health));
+  });
+
+  // ─── Chat Settings ───────────────────────────────────────────────────────
+  // GET /api/v1/settings/chat — settings + provider list + models + health + prompt defaults
+  fastify.get('/chat', async (request, reply) => {
+    const tenantId = request.agent.tenantId;
+    const settings = await getChatSettings(fastify.prisma, tenantId);
+    const [models, health] = await Promise.all([
+      listChatModels(settings.provider, settings.baseUrl),
+      checkChatHealth(settings.provider, settings.model, settings.baseUrl),
+    ]);
+    return reply.send(
+      success({
+        settings,
+        providers: getProviderList(),
+        models,
+        health,
+        defaults: {
+          chatSystemPrompt: CRM_REPLY_SYSTEM_PROMPT,
+          summarizeSystemPrompt: SUMMARIZE_SYSTEM_PROMPT,
+          clarifySystemPrompt: CLARIFY_SYSTEM_PROMPT,
+        },
+      }),
+    );
+  });
+
+  // PUT /api/v1/settings/chat — update settings
+  fastify.put('/chat', async (request, reply) => {
+    const patch = chatSettingsSchema.parse(request.body);
+    const result = await updateChatSettings(
+      fastify.prisma,
+      request.agent.tenantId,
+      patch,
+    );
+    return reply.send(success(result));
+  });
+
+  // GET /api/v1/settings/chat/models?provider=gemini&baseUrl=...
+  fastify.get('/chat/models', async (request, reply) => {
+    const q = chatModelsQuery.parse(request.query);
+    const models = await listChatModels(q.provider, q.baseUrl);
+    return reply.send(success({ models }));
+  });
+
+  // POST /api/v1/settings/chat/health — re-check health on demand
+  fastify.post('/chat/health', async (request, reply) => {
+    const settings = await getChatSettings(fastify.prisma, request.agent.tenantId);
+    const health = await checkChatHealth(settings.provider, settings.model, settings.baseUrl);
+    return reply.send(success(health));
+  });
 }
+
+const embeddingSettingsSchema = z.object({
+  baseUrl: z.string().url().optional(),
+  model: z.string().min(1).optional(),
+  topK: z.number().int().min(1).max(20).optional(),
+  threshold: z.number().min(0).max(1).optional(),
+});
+
+const chatSettingsSchema = z.object({
+  provider: z.enum(['ollama', 'gemini']).optional(),
+  model: z.string().min(1).optional(),
+  baseUrl: z.string().url().optional(),
+  temperature: z.number().min(0).max(2).optional(),
+  maxTokens: z.number().int().min(1).max(8192).optional(),
+  chatSystemPrompt: z.string().optional(),
+  summarizeSystemPrompt: z.string().optional(),
+  clarifySystemPrompt: z.string().optional(),
+  clarifyThreshold: z.number().min(0).max(1).optional(),
+  clarifyMaxAttempts: z.number().int().min(0).max(5).optional(),
+});
+
+const chatModelsQuery = z.object({
+  provider: z.enum(['ollama', 'gemini']),
+  baseUrl: z.string().url().optional(),
+});

--- a/apps/web/src/app/dashboard/knowledge/page.tsx
+++ b/apps/web/src/app/dashboard/knowledge/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import React, { useState, useCallback } from 'react';
-import { Plus, RefreshCw, Upload, Search, Loader2, Brain } from 'lucide-react';
+import { Plus, Upload, Search, Loader2, Brain } from 'lucide-react';
 import { useKnowledge, useCategories } from '@/hooks/useKnowledge';
 import { ArticleList } from '@/components/knowledge/ArticleList';
 import { ArticleFormDialog } from '@/components/knowledge/ArticleFormDialog';
 import { ImportDialog } from '@/components/knowledge/ImportDialog';
+import { EmbeddingSettings } from '@/components/knowledge/EmbeddingSettings';
+import { ChatPromptSettings } from '@/components/knowledge/ChatPromptSettings';
 import { Topbar } from '@/components/layout/Topbar';
 import { SearchInput } from '@/components/shared/SearchInput';
 import { Button } from '@/components/ui/button';
@@ -29,8 +31,7 @@ export default function KnowledgePage() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingArticle, setEditingArticle] = useState<any>(null);
   const [importOpen, setImportOpen] = useState(false);
-  const [bulkEmbedding, setBulkEmbedding] = useState(false);
-  const [pageTab, setPageTab] = useState<'articles' | 'search'>('articles');
+  const [pageTab, setPageTab] = useState<'articles' | 'search' | 'embedding' | 'chat'>('articles');
 
   // Semantic search state
   const [searchQuery, setSearchQuery] = useState('');
@@ -105,20 +106,6 @@ export default function KnowledgePage() {
     setDialogOpen(true);
   }, []);
 
-  const handleBulkEmbed = useCallback(async () => {
-    setBulkEmbedding(true);
-    try {
-      const res = await api.post('/knowledge/bulk-embed');
-      const { total, succeeded, failed } = res.data.data;
-      alert(`向量化完成：共 ${total} 篇，成功 ${succeeded} 篇，失敗 ${failed} 篇`);
-      mutate();
-    } catch (err: any) {
-      alert(err.response?.data?.error?.message || '向量化失敗');
-    } finally {
-      setBulkEmbedding(false);
-    }
-  }, [mutate]);
-
   const handleSemanticSearch = useCallback(async () => {
     if (!searchQuery.trim()) return;
     setSearching(true);
@@ -146,10 +133,12 @@ export default function KnowledgePage() {
 
       {/* Top-level page tabs: articles vs semantic search */}
       <div className="border-b px-6 pt-2">
-        <Tabs value={pageTab} onValueChange={(v) => setPageTab(v as 'articles' | 'search')}>
+        <Tabs value={pageTab} onValueChange={(v) => setPageTab(v as 'articles' | 'search' | 'embedding' | 'chat')}>
           <TabsList>
             <TabsTrigger value="articles">文章管理</TabsTrigger>
             <TabsTrigger value="search">語義搜尋</TabsTrigger>
+            <TabsTrigger value="embedding">Embedding 設定</TabsTrigger>
+            <TabsTrigger value="chat">Chat & Prompt</TabsTrigger>
           </TabsList>
 
           {/* ── Articles Tab ──────────────────────────────────── */}
@@ -173,19 +162,6 @@ export default function KnowledgePage() {
                   <Button variant="outline" size="sm" onClick={() => setImportOpen(true)}>
                     <Upload className="mr-1.5 h-4 w-4" />
                     匯入文章
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleBulkEmbed}
-                    disabled={bulkEmbedding}
-                  >
-                    {bulkEmbedding ? (
-                      <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
-                    ) : (
-                      <RefreshCw className="mr-1.5 h-4 w-4" />
-                    )}
-                    重新向量化
                   </Button>
                   <Button onClick={handleNewArticle}>
                     <Plus className="mr-2 h-4 w-4" />
@@ -287,6 +263,20 @@ export default function KnowledgePage() {
                   輸入關鍵字進行語義搜尋，系統會根據向量相似度找到最相關的知識庫文章
                 </p>
               )}
+            </div>
+          </TabsContent>
+
+          {/* ── Embedding Settings Tab ────────────────────────── */}
+          <TabsContent value="embedding">
+            <div className="h-[calc(100vh-180px)] overflow-y-auto py-4 pr-2">
+              <EmbeddingSettings />
+            </div>
+          </TabsContent>
+
+          {/* ── Chat & Prompt Settings Tab ────────────────────── */}
+          <TabsContent value="chat">
+            <div className="h-[calc(100vh-180px)] overflow-y-auto py-4 pr-2">
+              <ChatPromptSettings />
             </div>
           </TabsContent>
         </Tabs>

--- a/apps/web/src/components/knowledge/ArticleFormDialog.tsx
+++ b/apps/web/src/components/knowledge/ArticleFormDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useMemo } from 'react';
-import { Loader2, Eye, Pencil } from 'lucide-react';
+import { Loader2, Eye, Pencil, Paperclip, ExternalLink } from 'lucide-react';
 import api from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -24,8 +24,26 @@ interface ArticleFormDialogProps {
     content: string;
     category: string;
     tags: string[];
+    externalDocId?: string | null;
+    externalVer?: number;
+    externalSource?: string | null;
+    spec?: unknown;
+    importedAt?: string | null;
+    attachments?: {
+      id: string;
+      filename: string;
+      url: string;
+      mimeType: string;
+      sizeBytes: number;
+    }[];
   } | null;
   onSaved: () => void;
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
 }
 
 export function ArticleFormDialog({
@@ -117,6 +135,65 @@ export function ArticleFormDialog({
 
         <form onSubmit={handleSubmit}>
           <div className="space-y-4">
+            {article?.externalDocId && (
+              <div className="rounded-lg border bg-muted/30 p-3 text-xs">
+                <div className="mb-2 flex items-center gap-2">
+                  <span className="font-medium">合作方匯入</span>
+                  <code className="rounded bg-background px-1.5 py-0.5">
+                    DocID {article.externalDocId}
+                  </code>
+                  <code className="rounded bg-background px-1.5 py-0.5">
+                    v{article.externalVer ?? 0}
+                  </code>
+                  {article.externalSource && (
+                    <span className="text-muted-foreground">{article.externalSource}</span>
+                  )}
+                </div>
+                {article.importedAt && (
+                  <div className="text-muted-foreground">
+                    匯入時間：{new Date(article.importedAt).toLocaleString('zh-TW')}
+                  </div>
+                )}
+                {article.spec !== undefined && article.spec !== null && (
+                  <details className="mt-2">
+                    <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
+                      Spec
+                    </summary>
+                    <pre className="mt-2 max-h-40 overflow-auto rounded bg-background p-2 text-[10px]">
+                      {JSON.stringify(article.spec, null, 2)}
+                    </pre>
+                  </details>
+                )}
+                {article.attachments && article.attachments.length > 0 && (
+                  <div className="mt-2">
+                    <div className="mb-1 flex items-center gap-1 text-muted-foreground">
+                      <Paperclip className="h-3 w-3" />
+                      <span>附件 ({article.attachments.length})</span>
+                    </div>
+                    <ul className="space-y-1">
+                      {article.attachments.map((a) => (
+                        <li key={a.id} className="flex items-center justify-between rounded border bg-background px-2 py-1">
+                          <span className="truncate">{a.filename}</span>
+                          <span className="ml-2 flex shrink-0 items-center gap-2 text-muted-foreground">
+                            <span>{formatBytes(a.sizeBytes)}</span>
+                            <a
+                              href={a.url}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="inline-flex items-center hover:text-foreground"
+                              title="開啟附件"
+                            >
+                              <ExternalLink className="h-3 w-3" />
+                            </a>
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            )}
+
             <div>
               <label className="mb-1.5 block text-sm font-medium">標題</label>
               <Input

--- a/apps/web/src/components/knowledge/ArticleList.tsx
+++ b/apps/web/src/components/knowledge/ArticleList.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { format } from 'date-fns';
-import { Loader2, BookOpen, Edit, Globe, Archive, Trash2, Brain } from 'lucide-react';
+import { Loader2, BookOpen, Edit, Globe, Archive, Trash2, Brain, Paperclip } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/shared/EmptyState';
@@ -17,6 +17,9 @@ interface Article {
   viewCount: number;
   updatedAt: string;
   hasEmbedding?: boolean;
+  externalDocId?: string | null;
+  externalVer?: number;
+  _count?: { attachments: number };
 }
 
 interface ArticleListProps {
@@ -110,6 +113,22 @@ export function ArticleList({
                       <p className="mt-0.5 text-xs text-muted-foreground line-clamp-1">
                         {article.summary}
                       </p>
+                    )}
+                    {(article.externalDocId || (article._count?.attachments ?? 0) > 0) && (
+                      <div className="mt-1 flex items-center gap-2 text-[10px] text-muted-foreground">
+                        {article.externalDocId && (
+                          <span>
+                            DocID {article.externalDocId}
+                            {article.externalVer ? ` · v${article.externalVer}` : ''}
+                          </span>
+                        )}
+                        {(article._count?.attachments ?? 0) > 0 && (
+                          <span className="inline-flex items-center gap-0.5">
+                            <Paperclip className="h-3 w-3" />
+                            {article._count?.attachments}
+                          </span>
+                        )}
+                      </div>
                     )}
                   </div>
                 </div>

--- a/apps/web/src/components/knowledge/ChatPromptSettings.tsx
+++ b/apps/web/src/components/knowledge/ChatPromptSettings.tsx
@@ -1,0 +1,533 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select } from '@/components/ui/select';
+import api from '@/lib/api';
+
+interface ChatSettingsData {
+  provider: 'ollama' | 'gemini';
+  model: string;
+  baseUrl: string;
+  temperature: number;
+  maxTokens: number;
+  chatSystemPrompt: string;
+  summarizeSystemPrompt: string;
+  clarifySystemPrompt: string;
+  clarifyThreshold: number;
+  clarifyMaxAttempts: number;
+}
+
+interface ProviderInfo {
+  id: string;
+  label: string;
+}
+
+interface ModelInfo {
+  id: string;
+  label: string;
+  inputTokenLimit?: number;
+  outputTokenLimit?: number;
+  tier?: 'stable' | 'latest' | 'preview' | 'open-source';
+}
+
+interface ChatHealth {
+  ok: boolean;
+  reachable: boolean;
+  modelInstalled: boolean;
+  currentModel: string;
+  error?: string;
+}
+
+interface SettingsResponse {
+  settings: ChatSettingsData;
+  providers: ProviderInfo[];
+  models: ModelInfo[];
+  health: ChatHealth;
+  defaults: {
+    chatSystemPrompt: string;
+    summarizeSystemPrompt: string;
+    clarifySystemPrompt: string;
+  };
+}
+
+const DEFAULT_SETTINGS: ChatSettingsData = {
+  provider: 'ollama',
+  model: 'qwen2.5:3b',
+  baseUrl: 'http://localhost:11434',
+  temperature: 0.3,
+  maxTokens: 500,
+  chatSystemPrompt: '',
+  summarizeSystemPrompt: '',
+  clarifySystemPrompt: '',
+  clarifyThreshold: 0.5,
+  clarifyMaxAttempts: 2,
+};
+
+export function ChatPromptSettings() {
+  const [settings, setSettings] = useState<ChatSettingsData>(DEFAULT_SETTINGS);
+  const [providers, setProviders] = useState<ProviderInfo[]>([]);
+  const [models, setModels] = useState<ModelInfo[]>([]);
+  const [health, setHealth] = useState<ChatHealth | null>(null);
+  const [defaults, setDefaults] = useState({
+    chatSystemPrompt: '',
+    summarizeSystemPrompt: '',
+    clarifySystemPrompt: '',
+  });
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [customModel, setCustomModel] = useState(false);
+
+  const fetchAll = useCallback(async () => {
+    try {
+      const res = await api.get<{ data: SettingsResponse }>('/settings/chat');
+      const d = res.data.data;
+      setSettings(d.settings);
+      setProviders(d.providers);
+      setModels(d.models);
+      setHealth(d.health);
+      setDefaults(d.defaults);
+    } catch (err) {
+      console.error('Failed to fetch chat settings:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  // Reload model list when provider or baseUrl changes (after debounce on URL)
+  const reloadModels = useCallback(
+    async (provider: string, baseUrl: string) => {
+      try {
+        const res = await api.get<{ data: { models: ModelInfo[] } }>('/settings/chat/models', {
+          params: { provider, baseUrl: provider === 'ollama' ? baseUrl : undefined },
+        });
+        setModels(res.data.data.models);
+      } catch (err) {
+        console.error('Failed to reload models:', err);
+        setModels([]);
+      }
+    },
+    [],
+  );
+
+  const handleProviderChange = async (newProvider: string) => {
+    const provider = newProvider as 'ollama' | 'gemini';
+    // When switching provider, snap model to a sensible default
+    const defaultModel = provider === 'gemini' ? 'gemini-2.5-flash' : 'qwen2.5:3b';
+    setSettings({ ...settings, provider, model: defaultModel });
+    await reloadModels(provider, settings.baseUrl);
+  };
+
+  const persistSettings = async (next: ChatSettingsData) => {
+    setSaving(true);
+    try {
+      await api.put('/settings/chat', next);
+      await fetchAll();
+    } catch (err) {
+      console.error('Failed to save chat settings:', err);
+      alert('儲存失敗');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const recheckHealth = async () => {
+    try {
+      const res = await api.post<{ data: ChatHealth }>('/settings/chat/health');
+      setHealth(res.data.data);
+    } catch (err) {
+      console.error('Failed to recheck health:', err);
+    }
+  };
+
+  if (loading) return <div className="text-sm text-muted-foreground">載入中…</div>;
+
+  const healthBadge = health?.ok ? (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-700">
+      <span className="h-1.5 w-1.5 rounded-full bg-green-500" /> 連線正常
+    </span>
+  ) : (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-700">
+      <span className="h-1.5 w-1.5 rounded-full bg-red-500" /> 異常
+    </span>
+  );
+
+  const providerLabel = providers.find((p) => p.id === settings.provider)?.label ?? settings.provider;
+
+  // group Gemini models by tier for clearer dropdown
+  const groupedModels = settings.provider === 'gemini'
+    ? {
+        stable: models.filter((m) => m.tier === 'stable'),
+        latest: models.filter((m) => m.tier === 'latest'),
+        preview: models.filter((m) => m.tier === 'preview'),
+      }
+    : null;
+
+  return (
+    <div className="space-y-6 max-w-3xl">
+      <div>
+        <h2 className="text-lg font-semibold">Chat & RAG 設定</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          設定 KB 自動回覆與對話摘要使用的 LLM 提供者、模型、生成參數，以及系統提示詞。
+        </p>
+      </div>
+
+      {/* ─── 服務狀態 ────────────────────────── */}
+      <section className="rounded-lg border bg-card p-5">
+        <div className="flex items-start justify-between">
+          <div>
+            <h3 className="text-sm font-semibold">服務狀態</h3>
+            <p className="mt-1 text-xs text-muted-foreground">
+              檢查所選 Provider 是否可達，以及目前模型是否可用。
+            </p>
+          </div>
+          <Button variant="outline" size="sm" onClick={recheckHealth}>
+            重新檢測
+          </Button>
+        </div>
+        <div className="mt-4 space-y-2 text-sm">
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground w-20">狀態</span>
+            {healthBadge}
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground w-20">Provider</span>
+            <code className="rounded bg-muted px-1.5 py-0.5 text-xs">{providerLabel}</code>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground w-20">目前模型</span>
+            <code className="rounded bg-muted px-1.5 py-0.5 text-xs">{health?.currentModel}</code>
+          </div>
+          {health?.error && (
+            <div className="mt-2 rounded-md bg-red-50 p-2 text-xs text-red-700">{health.error}</div>
+          )}
+        </div>
+      </section>
+
+      {/* ─── Provider / 模型 ────────────────────────── */}
+      <section className="rounded-lg border bg-card p-5">
+        <h3 className="text-sm font-semibold">Provider 與模型</h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          切換 Provider 後請接著選擇對應模型；Gemini 共用平台 API key（管理員 .env 設定）。
+        </p>
+
+        <div className="mt-4 grid grid-cols-1 gap-4">
+          <div>
+            <label className="mb-1.5 block text-xs font-medium">Provider</label>
+            <Select
+              value={settings.provider}
+              onChange={(e) => handleProviderChange(e.target.value)}
+              options={providers.map((p) => ({ value: p.id, label: p.label }))}
+            />
+          </div>
+
+          {settings.provider === 'ollama' && (
+            <div>
+              <label className="mb-1.5 block text-xs font-medium">Ollama Base URL</label>
+              <Input
+                value={settings.baseUrl}
+                onChange={(e) => setSettings({ ...settings, baseUrl: e.target.value })}
+                onBlur={() => reloadModels(settings.provider, settings.baseUrl)}
+                placeholder="http://localhost:11434"
+              />
+            </div>
+          )}
+
+          <div>
+            <div className="mb-1.5 flex items-center justify-between">
+              <label className="text-xs font-medium">模型</label>
+              <button
+                type="button"
+                onClick={() => setCustomModel((v) => !v)}
+                className="text-xs text-primary hover:underline"
+              >
+                {customModel ? '從清單選擇' : '自訂輸入'}
+              </button>
+            </div>
+
+            {customModel || models.length === 0 ? (
+              <Input
+                value={settings.model}
+                onChange={(e) => setSettings({ ...settings, model: e.target.value })}
+                placeholder={settings.provider === 'gemini' ? 'gemini-2.5-flash' : 'qwen2.5:3b'}
+              />
+            ) : groupedModels ? (
+              <select
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                value={settings.model}
+                onChange={(e) => setSettings({ ...settings, model: e.target.value })}
+              >
+                {groupedModels.stable.length > 0 && (
+                  <optgroup label="穩定版">
+                    {groupedModels.stable.map((m) => (
+                      <option key={m.id} value={m.id}>{m.label}</option>
+                    ))}
+                  </optgroup>
+                )}
+                {groupedModels.latest.length > 0 && (
+                  <optgroup label="Latest（自動跟版）">
+                    {groupedModels.latest.map((m) => (
+                      <option key={m.id} value={m.id}>{m.label}</option>
+                    ))}
+                  </optgroup>
+                )}
+                {groupedModels.preview.length > 0 && (
+                  <optgroup label="Preview（測試版，不穩定）">
+                    {groupedModels.preview.map((m) => (
+                      <option key={m.id} value={m.id}>{m.label}</option>
+                    ))}
+                  </optgroup>
+                )}
+                {/* if current model is not in any group, show it */}
+                {!models.some((m) => m.id === settings.model) && (
+                  <option value={settings.model}>{settings.model}（自訂）</option>
+                )}
+              </select>
+            ) : (
+              <Select
+                value={settings.model}
+                onChange={(e) => setSettings({ ...settings, model: e.target.value })}
+                options={[
+                  ...(models.some((m) => m.id === settings.model || m.id.startsWith(`${settings.model}:`))
+                    ? []
+                    : [{ value: settings.model, label: `${settings.model}（未安裝）` }]),
+                  ...models.map((m) => ({ value: m.id, label: m.label })),
+                ]}
+              />
+            )}
+          </div>
+        </div>
+
+        <div className="mt-4 flex justify-end">
+          <Button onClick={() => persistSettings(settings)} disabled={saving}>
+            {saving ? '儲存中…' : '儲存'}
+          </Button>
+        </div>
+      </section>
+
+      {/* ─── 生成參數 ────────────────────────── */}
+      <section className="rounded-lg border bg-card p-5">
+        <h3 className="text-sm font-semibold">生成參數</h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          temperature 控制創意程度（越高越發散），max tokens 控制回覆長度上限。
+        </p>
+
+        <div className="mt-4 space-y-4">
+          <div>
+            <div className="mb-1.5 flex items-center justify-between text-xs">
+              <label className="font-medium">Temperature</label>
+              <span className="text-muted-foreground">{settings.temperature.toFixed(2)}</span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.05}
+              value={settings.temperature}
+              onChange={(e) => setSettings({ ...settings, temperature: Number(e.target.value) })}
+              className="w-full accent-primary"
+            />
+            <div className="flex justify-between text-[10px] text-muted-foreground">
+              <span>0.00 嚴謹</span>
+              <span>0.50</span>
+              <span>1.00 發散</span>
+            </div>
+          </div>
+
+          <div>
+            <div className="mb-1.5 flex items-center justify-between text-xs">
+              <label className="font-medium">Max Tokens（回覆長度上限）</label>
+              <span className="text-muted-foreground">{settings.maxTokens}</span>
+            </div>
+            <input
+              type="range"
+              min={50}
+              max={2000}
+              step={50}
+              value={settings.maxTokens}
+              onChange={(e) => setSettings({ ...settings, maxTokens: Number(e.target.value) })}
+              className="w-full accent-primary"
+            />
+            <div className="flex justify-between text-[10px] text-muted-foreground">
+              <span>50</span>
+              <span>1000</span>
+              <span>2000</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-4 flex justify-end">
+          <Button onClick={() => persistSettings(settings)} disabled={saving}>
+            {saving ? '儲存中…' : '儲存'}
+          </Button>
+        </div>
+      </section>
+
+      {/* ─── System Prompt：客服回覆 ────────────────────────── */}
+      <section className="rounded-lg border bg-card p-5">
+        <div className="flex items-start justify-between">
+          <div>
+            <h3 className="text-sm font-semibold">客服回覆 System Prompt</h3>
+            <p className="mt-1 text-xs text-muted-foreground">
+              用於 KB 自動回覆、Suggest Reply、自動化規則的 LLM Reply 動作。留空表示使用預設提示詞。
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setSettings({ ...settings, chatSystemPrompt: defaults.chatSystemPrompt })}
+          >
+            還原預設
+          </Button>
+        </div>
+        <textarea
+          className="mt-3 min-h-[180px] w-full rounded-md border bg-background p-3 font-mono text-xs"
+          value={settings.chatSystemPrompt}
+          onChange={(e) => setSettings({ ...settings, chatSystemPrompt: e.target.value })}
+          placeholder={defaults.chatSystemPrompt}
+        />
+        <div className="mt-2 flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">
+            {settings.chatSystemPrompt.length} 字
+            {settings.chatSystemPrompt.length === 0 && '（將使用預設）'}
+          </span>
+          <Button onClick={() => persistSettings(settings)} disabled={saving}>
+            {saving ? '儲存中…' : '儲存'}
+          </Button>
+        </div>
+      </section>
+
+      {/* ─── System Prompt：對話摘要 ────────────────────────── */}
+      <section className="rounded-lg border bg-card p-5">
+        <div className="flex items-start justify-between">
+          <div>
+            <h3 className="text-sm font-semibold">對話摘要 System Prompt</h3>
+            <p className="mt-1 text-xs text-muted-foreground">
+              用於 「AI 摘要對話」功能。留空表示使用預設提示詞。
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              setSettings({ ...settings, summarizeSystemPrompt: defaults.summarizeSystemPrompt })
+            }
+          >
+            還原預設
+          </Button>
+        </div>
+        <textarea
+          className="mt-3 min-h-[120px] w-full rounded-md border bg-background p-3 font-mono text-xs"
+          value={settings.summarizeSystemPrompt}
+          onChange={(e) => setSettings({ ...settings, summarizeSystemPrompt: e.target.value })}
+          placeholder={defaults.summarizeSystemPrompt}
+        />
+        <div className="mt-2 flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">
+            {settings.summarizeSystemPrompt.length} 字
+            {settings.summarizeSystemPrompt.length === 0 && '（將使用預設）'}
+          </span>
+          <Button onClick={() => persistSettings(settings)} disabled={saving}>
+            {saving ? '儲存中…' : '儲存'}
+          </Button>
+        </div>
+      </section>
+
+      {/* ─── 多輪追問（Clarify）────────────────────────── */}
+      <section className="rounded-lg border bg-card p-5">
+        <h3 className="text-sm font-semibold">多輪追問（Clarify）</h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          當客戶訊息資訊不足、知識庫信心低於門檻時，Bot 會用此提示詞反問一個澄清問題，
+          而不是直接回覆或交給真人。達到追問次數上限後會自動轉接客服。
+        </p>
+
+        <div className="mt-4 space-y-4">
+          <div>
+            <div className="mb-1.5 flex items-center justify-between text-xs">
+              <label className="font-medium">觸發門檻（KB top similarity 低於此值就改用追問）</label>
+              <span className="text-muted-foreground">{settings.clarifyThreshold.toFixed(2)}</span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.05}
+              value={settings.clarifyThreshold}
+              onChange={(e) =>
+                setSettings({ ...settings, clarifyThreshold: Number(e.target.value) })
+              }
+              className="w-full accent-primary"
+            />
+            <div className="flex justify-between text-[10px] text-muted-foreground">
+              <span>0.00（總是追問）</span>
+              <span>0.50</span>
+              <span>1.00（從不追問）</span>
+            </div>
+          </div>
+
+          <div>
+            <div className="mb-1.5 flex items-center justify-between text-xs">
+              <label className="font-medium">最大追問次數（達到後自動 handoff）</label>
+              <span className="text-muted-foreground">{settings.clarifyMaxAttempts}</span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={5}
+              step={1}
+              value={settings.clarifyMaxAttempts}
+              onChange={(e) =>
+                setSettings({ ...settings, clarifyMaxAttempts: Number(e.target.value) })
+              }
+              className="w-full accent-primary"
+            />
+            <div className="flex justify-between text-[10px] text-muted-foreground">
+              <span>0</span>
+              <span>2（推薦）</span>
+              <span>5</span>
+            </div>
+          </div>
+
+          <div>
+            <div className="mb-1.5 flex items-center justify-between">
+              <label className="text-xs font-medium">Clarify System Prompt</label>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  setSettings({ ...settings, clarifySystemPrompt: defaults.clarifySystemPrompt })
+                }
+              >
+                還原預設
+              </Button>
+            </div>
+            <textarea
+              className="min-h-[140px] w-full rounded-md border bg-background p-3 font-mono text-xs"
+              value={settings.clarifySystemPrompt}
+              onChange={(e) =>
+                setSettings({ ...settings, clarifySystemPrompt: e.target.value })
+              }
+              placeholder={defaults.clarifySystemPrompt}
+            />
+            <span className="text-xs text-muted-foreground">
+              {settings.clarifySystemPrompt.length} 字
+              {settings.clarifySystemPrompt.length === 0 && '（將使用預設）'}
+            </span>
+          </div>
+        </div>
+
+        <div className="mt-4 flex justify-end">
+          <Button onClick={() => persistSettings(settings)} disabled={saving}>
+            {saving ? '儲存中…' : '儲存'}
+          </Button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/components/knowledge/EmbeddingSettings.tsx
+++ b/apps/web/src/components/knowledge/EmbeddingSettings.tsx
@@ -1,0 +1,409 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select } from '@/components/ui/select';
+import api from '@/lib/api';
+
+interface EmbeddingSettingsData {
+  baseUrl: string;
+  model: string;
+  topK: number;
+  threshold: number;
+}
+
+interface OllamaModel {
+  name: string;
+  size?: number;
+}
+
+interface OllamaHealth {
+  ok: boolean;
+  reachable: boolean;
+  modelInstalled: boolean;
+  currentModel: string;
+  error?: string;
+}
+
+interface EmbeddingStats {
+  total: number;
+  embedded: number;
+  missing: number;
+}
+
+interface SettingsResponse {
+  settings: EmbeddingSettingsData;
+  health: OllamaHealth;
+  models: OllamaModel[];
+  stats: EmbeddingStats;
+  vectorDim: number;
+}
+
+const DEFAULT_SETTINGS: EmbeddingSettingsData = {
+  baseUrl: 'http://localhost:11434',
+  model: 'bge-m3',
+  topK: 5,
+  threshold: 0.3,
+};
+
+export function EmbeddingSettings() {
+  const [settings, setSettings] = useState<EmbeddingSettingsData>(DEFAULT_SETTINGS);
+  const [originalModel, setOriginalModel] = useState(DEFAULT_SETTINGS.model);
+  const [health, setHealth] = useState<OllamaHealth | null>(null);
+  const [models, setModels] = useState<OllamaModel[]>([]);
+  const [stats, setStats] = useState<EmbeddingStats | null>(null);
+  const [vectorDim, setVectorDim] = useState(1024);
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [reembedding, setReembedding] = useState(false);
+  const [reembedResult, setReembedResult] = useState<{ total: number; succeeded: number; failed: number } | null>(null);
+  const [confirmModelChange, setConfirmModelChange] = useState<{ from: string; to: string } | null>(null);
+  const [customModel, setCustomModel] = useState(false);
+
+  const fetchAll = useCallback(async () => {
+    try {
+      const res = await api.get<{ data: SettingsResponse }>('/settings/embedding');
+      const data = res.data.data;
+      setSettings(data.settings);
+      setOriginalModel(data.settings.model);
+      setHealth(data.health);
+      setModels(data.models);
+      setStats(data.stats);
+      setVectorDim(data.vectorDim);
+    } catch (err) {
+      console.error('Failed to fetch embedding settings:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  const recheckHealth = async () => {
+    try {
+      const res = await api.post<{ data: OllamaHealth }>('/settings/embedding/health');
+      setHealth(res.data.data);
+    } catch (err) {
+      console.error('Failed to recheck health:', err);
+    }
+  };
+
+  const persistSettings = async (next: EmbeddingSettingsData) => {
+    setSaving(true);
+    try {
+      await api.put('/settings/embedding', next);
+      setOriginalModel(next.model);
+      // refresh derived data (health, stats) since model/baseUrl may have changed
+      await fetchAll();
+    } catch (err) {
+      console.error('Failed to save embedding settings:', err);
+      alert('儲存失敗');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSaveModelOrUrl = async () => {
+    if (settings.model !== originalModel) {
+      setConfirmModelChange({ from: originalModel, to: settings.model });
+      return;
+    }
+    await persistSettings(settings);
+  };
+
+  const confirmAndPersist = async () => {
+    if (!confirmModelChange) return;
+    setConfirmModelChange(null);
+    await persistSettings(settings);
+  };
+
+  const handleSaveSearchParams = async () => {
+    await persistSettings(settings);
+  };
+
+  const runBulkReembed = async () => {
+    setReembedding(true);
+    setReembedResult(null);
+    try {
+      const res = await api.post<{ data: { total: number; succeeded: number; failed: number } }>(
+        '/knowledge/bulk-embed',
+      );
+      setReembedResult(res.data.data);
+      // refresh stats
+      const refresh = await api.get<{ data: SettingsResponse }>('/settings/embedding');
+      setStats(refresh.data.data.stats);
+    } catch (err) {
+      console.error('Bulk re-embed failed:', err);
+      alert('重新嵌入失敗');
+    } finally {
+      setReembedding(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="text-sm text-muted-foreground">載入中…</div>;
+  }
+
+  const healthBadge = health?.ok ? (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-700">
+      <span className="h-1.5 w-1.5 rounded-full bg-green-500" /> 連線正常
+    </span>
+  ) : (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-700">
+      <span className="h-1.5 w-1.5 rounded-full bg-red-500" /> 異常
+    </span>
+  );
+
+  return (
+    <div className="space-y-6 max-w-3xl">
+      <div>
+        <h2 className="text-lg font-semibold">AI / 向量設定</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          設定知識庫向量化所使用的 Ollama 服務、模型，以及語意搜尋的 topK 與相似度門檻。
+        </p>
+      </div>
+
+      {/* ─── 服務狀態 ────────────────────────── */}
+      <section className="rounded-lg border bg-card p-5">
+        <div className="flex items-start justify-between">
+          <div>
+            <h3 className="text-sm font-semibold">Ollama 服務狀態</h3>
+            <p className="mt-1 text-xs text-muted-foreground">
+              檢查 Ollama 是否可達，以及目前選擇的 embedding 模型是否已安裝。
+            </p>
+          </div>
+          <Button variant="outline" size="sm" onClick={recheckHealth}>
+            重新檢測
+          </Button>
+        </div>
+        <div className="mt-4 space-y-2 text-sm">
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground w-20">狀態</span>
+            {healthBadge}
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground w-20">目前模型</span>
+            <code className="rounded bg-muted px-1.5 py-0.5 text-xs">{health?.currentModel}</code>
+            {health?.modelInstalled ? (
+              <span className="text-xs text-green-600">已安裝</span>
+            ) : (
+              <span className="text-xs text-red-600">未安裝</span>
+            )}
+          </div>
+          {health?.error && (
+            <div className="mt-2 rounded-md bg-red-50 p-2 text-xs text-red-700">
+              {health.error}
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* ─── 模型設定 ────────────────────────── */}
+      <section className="rounded-lg border bg-card p-5">
+        <h3 className="text-sm font-semibold">模型設定</h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          向量維度固定為 <code className="rounded bg-muted px-1 py-0.5">{vectorDim}</code>
+          ，請選擇相同維度的模型（例：bge-m3、multilingual-e5-large）。切換模型後現有向量會失效，需要重新嵌入。
+        </p>
+
+        <div className="mt-4 grid grid-cols-1 gap-4">
+          <div>
+            <label className="mb-1.5 block text-xs font-medium">Ollama Base URL</label>
+            <Input
+              value={settings.baseUrl}
+              onChange={(e) => setSettings({ ...settings, baseUrl: e.target.value })}
+              placeholder="http://localhost:11434"
+            />
+          </div>
+          <div>
+            <div className="mb-1.5 flex items-center justify-between">
+              <label className="text-xs font-medium">Embedding 模型</label>
+              <button
+                type="button"
+                onClick={() => setCustomModel((v) => !v)}
+                className="text-xs text-primary hover:underline"
+              >
+                {customModel ? '從清單選擇' : '自訂輸入'}
+              </button>
+            </div>
+
+            {customModel || models.length === 0 ? (
+              <Input
+                value={settings.model}
+                onChange={(e) => setSettings({ ...settings, model: e.target.value })}
+                placeholder="bge-m3"
+              />
+            ) : (
+              <Select
+                value={settings.model}
+                onChange={(e) => setSettings({ ...settings, model: e.target.value })}
+                options={[
+                  // 把目前設定值放最上面（即使本機沒安裝也保留）
+                  ...(models.some((m) => m.name === settings.model || m.name.startsWith(`${settings.model}:`))
+                    ? []
+                    : [{ value: settings.model, label: `${settings.model}（未安裝）` }]),
+                  ...models.map((m) => ({
+                    value: m.name.replace(/:latest$/, ''),
+                    label: m.name,
+                  })),
+                ]}
+              />
+            )}
+
+            <p className="mt-1.5 text-xs text-muted-foreground">
+              {models.length > 0
+                ? `已偵測到 ${models.length} 個本地模型`
+                : '尚未偵測到本地模型，請確認 Ollama 已啟動或切換 Base URL'}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-4 flex justify-end">
+          <Button onClick={handleSaveModelOrUrl} disabled={saving}>
+            {saving ? '儲存中…' : '儲存'}
+          </Button>
+        </div>
+      </section>
+
+      {/* ─── 搜尋參數 ────────────────────────── */}
+      <section className="rounded-lg border bg-card p-5">
+        <h3 className="text-sm font-semibold">語意搜尋參數</h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          影響 KB 自動回覆與 RAG 檢索行為。topK 越大召回越多、threshold 越低越寬鬆。
+        </p>
+
+        <div className="mt-4 space-y-4">
+          <div>
+            <div className="mb-1.5 flex items-center justify-between text-xs">
+              <label className="font-medium">topK（取前幾筆）</label>
+              <span className="text-muted-foreground">{settings.topK}</span>
+            </div>
+            <input
+              type="range"
+              min={1}
+              max={20}
+              step={1}
+              value={settings.topK}
+              onChange={(e) => setSettings({ ...settings, topK: Number(e.target.value) })}
+              className="w-full accent-primary"
+            />
+            <div className="flex justify-between text-[10px] text-muted-foreground">
+              <span>1</span>
+              <span>10</span>
+              <span>20</span>
+            </div>
+          </div>
+          <div>
+            <div className="mb-1.5 flex items-center justify-between text-xs">
+              <label className="font-medium">相似度門檻</label>
+              <span className="text-muted-foreground">{settings.threshold.toFixed(2)}</span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.05}
+              value={settings.threshold}
+              onChange={(e) => setSettings({ ...settings, threshold: Number(e.target.value) })}
+              className="w-full accent-primary"
+            />
+            <div className="flex justify-between text-[10px] text-muted-foreground">
+              <span>0.00 寬鬆</span>
+              <span>0.50</span>
+              <span>1.00 嚴格</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-4 flex justify-end">
+          <Button onClick={handleSaveSearchParams} disabled={saving}>
+            {saving ? '儲存中…' : '儲存'}
+          </Button>
+        </div>
+      </section>
+
+      {/* ─── 批次重新嵌入 ────────────────────────── */}
+      <section className="rounded-lg border bg-card p-5">
+        <h3 className="text-sm font-semibold">批次重新嵌入</h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          重新計算所有「已發布」文章的向量。切換模型後請執行這個。
+        </p>
+
+        {stats && (
+          <div className="mt-4 grid grid-cols-3 gap-3">
+            <StatBlock label="總文章數" value={stats.total} />
+            <StatBlock label="已嵌入" value={stats.embedded} tone="success" />
+            <StatBlock label="未嵌入" value={stats.missing} tone={stats.missing > 0 ? 'warning' : 'default'} />
+          </div>
+        )}
+
+        <div className="mt-4 flex items-center gap-3">
+          <Button onClick={runBulkReembed} disabled={reembedding}>
+            {reembedding ? '處理中…（可能需要數分鐘）' : '重新嵌入全部已發布文章'}
+          </Button>
+          {reembedResult && (
+            <span className="text-xs text-muted-foreground">
+              共 {reembedResult.total} 篇，成功 {reembedResult.succeeded}，失敗 {reembedResult.failed}
+            </span>
+          )}
+        </div>
+      </section>
+
+      {/* ─── 模型切換確認 Modal ────────────────────────── */}
+      {confirmModelChange && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="mx-4 max-w-md rounded-lg bg-background p-6 shadow-lg">
+            <h3 className="text-base font-semibold">確認切換模型？</h3>
+            <p className="mt-2 text-sm text-muted-foreground">
+              將從 <code className="rounded bg-muted px-1 py-0.5 text-xs">{confirmModelChange.from}</code>
+              {' '}切換為{' '}
+              <code className="rounded bg-muted px-1 py-0.5 text-xs">{confirmModelChange.to}</code>
+              。
+            </p>
+            <div className="mt-3 rounded-md bg-amber-50 p-3 text-xs text-amber-800">
+              <strong>注意：</strong>
+              不同模型產生的向量空間不相容。儲存後{' '}
+              <strong>所有現有向量將失效</strong>
+              ，知識庫搜尋會找不到結果，請接著執行「批次重新嵌入」。
+              <br />
+              另外，新模型必須輸出 {vectorDim} 維向量，否則嵌入會失敗。
+            </div>
+            <div className="mt-4 flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setConfirmModelChange(null)}>
+                取消
+              </Button>
+              <Button onClick={confirmAndPersist}>確認切換</Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatBlock({
+  label,
+  value,
+  tone = 'default',
+}: {
+  label: string;
+  value: number;
+  tone?: 'default' | 'success' | 'warning';
+}) {
+  const toneClass =
+    tone === 'success'
+      ? 'text-green-700'
+      : tone === 'warning'
+        ? 'text-amber-700'
+        : 'text-foreground';
+  return (
+    <div className="rounded-md border bg-muted/30 px-3 py-2.5">
+      <div className="text-[10px] text-muted-foreground">{label}</div>
+      <div className={`mt-0.5 text-xl font-semibold ${toneClass}`}>{value}</div>
+    </div>
+  );
+}

--- a/apps/workers/package.json
+++ b/apps/workers/package.json
@@ -15,6 +15,7 @@
     "@open333crm/types": "workspace:*",
     "@prisma/client": "^6.0.0",
     "bullmq": "^5.7.0",
+    "dotenv": "^17.4.2",
     "ioredis": "5.9.3",
     "winston": "^3.13.0"
   },

--- a/apps/workers/src/index.ts
+++ b/apps/workers/src/index.ts
@@ -1,3 +1,27 @@
+import { resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+import dotenv from 'dotenv';
+
+// Load env BEFORE any module that reads process.env at import time (e.g. BullMQ
+// queues constructed with `connection: { url: process.env.REDIS_URL }`).
+// Walk up from cwd until we find the monorepo root .env (covers both dev
+// where cwd=apps/workers and prod where it might be the package dir).
+function loadEnv(): void {
+  let dir = process.cwd();
+  for (let i = 0; i < 5; i++) {
+    const candidate = resolve(dir, '.env');
+    if (existsSync(candidate)) {
+      dotenv.config({ path: candidate });
+      return;
+    }
+    const parent = resolve(dir, '..');
+    if (parent === dir) break;
+    dir = parent;
+  }
+  dotenv.config(); // fall back to default (cwd/.env)
+}
+loadEnv();
+
 import { Worker, Queue } from 'bullmq';
 import IORedis from 'ioredis';
 import { PrismaClient } from '@prisma/client';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_USER: crm
       POSTGRES_PASSWORD: crmpassword
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
       - pg_data:/var/lib/postgresql/data
     healthcheck:

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -482,6 +482,7 @@ model Conversation {
   lastMessageAt   DateTime?
   botRepliesCount Int                @default(0)
   handoffReason   String?
+  metadata        Json               @default("{}")
   createdAt       DateTime           @default(now())
   updatedAt       DateTime           @updatedAt
 
@@ -751,13 +752,37 @@ model KmArticle {
   embeddingModel String?
   viewCount      Int                          @default(0)
   helpfulCount   Int                          @default(0)
+  externalDocId  String?                      @db.VarChar(64)
+  externalVer    Int                          @default(0)
+  externalSource String?
+  spec           Json?
+  importedAt     DateTime?
   createdById    String                       @db.Uuid
   updatedAt      DateTime                     @updatedAt
   createdAt      DateTime                     @default(now())
 
+  attachments KmArticleAttachment[]
+
+  @@unique([tenantId, externalDocId])
   @@index([tenantId, status])
   @@index([teamId])
   @@map("km_articles")
+}
+
+model KmArticleAttachment {
+  id         String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  articleId  String   @db.Uuid
+  filename   String
+  storageKey String
+  url        String
+  mimeType   String
+  sizeBytes  Int
+  createdAt  DateTime @default(now())
+
+  article KmArticle @relation(fields: [articleId], references: [id], onDelete: Cascade)
+
+  @@index([articleId])
+  @@map("km_article_attachments")
 }
 
 model LongTermMemory {
@@ -863,12 +888,26 @@ model DailyStat {
 }
 
 model TenantSettings {
-  id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  tenantId    String   @unique @db.Uuid
-  timezone    String   @default("Asia/Taipei")
-  officeHours Json     @default("{}")
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id                     String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId               String   @unique @db.Uuid
+  timezone               String   @default("Asia/Taipei")
+  officeHours            Json     @default("{}")
+  embeddingBaseUrl       String   @default("http://localhost:11434")
+  embeddingModel         String   @default("bge-m3")
+  embeddingTopK          Int      @default(5)
+  embeddingThreshold     Float    @default(0.3)
+  chatProvider           String   @default("ollama")
+  chatModel              String   @default("qwen2.5:3b")
+  chatBaseUrl            String   @default("http://localhost:11434")
+  chatTemperature        Float    @default(0.3)
+  chatMaxTokens          Int      @default(500)
+  chatSystemPrompt       String   @default("")
+  summarizeSystemPrompt  String   @default("")
+  clarifySystemPrompt    String   @default("")
+  clarifyThreshold       Float    @default(0.5)
+  clarifyMaxAttempts     Int      @default(2)
+  createdAt              DateTime @default(now())
+  updatedAt              DateTime @updatedAt
 
   tenant Tenant @relation(fields: [tenantId], references: [id])
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,9 @@ importers:
       bullmq:
         specifier: ^5.7.0
         version: 5.71.0
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       ioredis:
         specifier: 5.9.3
         version: 5.9.3
@@ -2407,6 +2410,10 @@ packages:
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
   duck@0.1.12:
@@ -6051,6 +6058,8 @@ snapshots:
   dlv@1.1.3: {}
 
   dotenv@16.6.1: {}
+
+  dotenv@17.4.2: {}
 
   duck@0.1.12:
     dependencies:

--- a/scripts/sim-inbound.sh
+++ b/scripts/sim-inbound.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Simulate an inbound customer message → triggers KB autoreply / clarify
+# Usage: ./sim-inbound.sh "壞了怎辦"
+#        ./sim-inbound.sh "請問冰箱保固多久"
+
+set -e
+
+MESSAGE="${1:-壞了怎辦}"
+CHANNEL_ID="${CHANNEL_ID:-d0000000-0000-0000-0000-000000000003}"  # WEBCHAT default
+CONTACT_UID="${CONTACT_UID:-webchat-user-chen}"
+CHANNEL_TYPE="${CHANNEL_TYPE:-WEBCHAT}"
+CONTACT_NAME="${CONTACT_NAME:-陳小芳}"
+
+API_BASE="http://localhost:3001/api/v1"
+
+# Login
+TOKEN=$(curl -s -X POST "$API_BASE/auth/login" \
+  -H "Content-Type: application/json" \
+  -d '{"email":"admin@demo.com","password":"admin123"}' \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['accessToken'])")
+
+if [ -z "$TOKEN" ]; then
+  echo "❌ Failed to login"
+  exit 1
+fi
+
+echo "📨 [→ $CHANNEL_TYPE / $CONTACT_NAME] $MESSAGE"
+RESP=$(curl -s -X POST "$API_BASE/simulator/send-message" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"channelType\": \"$CHANNEL_TYPE\",
+    \"channelId\": \"$CHANNEL_ID\",
+    \"contactUid\": \"$CONTACT_UID\",
+    \"contactName\": \"$CONTACT_NAME\",
+    \"contentType\": \"text\",
+    \"content\": {\"text\": \"$MESSAGE\"}
+  }")
+
+echo "$RESP" | python3 -m json.tool 2>/dev/null || echo "$RESP"
+
+# Wait for bot reply
+echo
+echo "⏳ Waiting 8s for KB autoreply / clarify…"
+sleep 8
+
+CONV_ID=$(echo "$RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('data', {}).get('conversation', {}).get('id', ''))" 2>/dev/null)
+
+if [ -n "$CONV_ID" ]; then
+  echo
+  echo "💬 Latest BOT message in conversation $CONV_ID:"
+  PGPASSWORD=crmpassword docker exec open333crm-postgres psql -U crm -d open333crm -t -c "
+    SELECT '  Reply: ' || (content->>'text') || E'\n  Kind:  ' || (metadata->>'replyKind') || E'\n  Sim:   ' || (metadata->>'confidence')
+    FROM messages
+    WHERE \"conversationId\" = '$CONV_ID' AND \"senderType\" = 'BOT'
+    ORDER BY \"createdAt\" DESC LIMIT 1;
+  " 2>/dev/null
+fi


### PR DESCRIPTION
## Summary

把先前散在 env / 寫死的 LLM 與 RAG 設定收斂為**租戶級可控**，並接上合作方（Stanley 端）的單筆推送 ingestion endpoint。

### 1. Embedding 設定（Per-tenant）
- `TenantSettings` 新增 `embeddingBaseUrl/Model/TopK/Threshold` 欄位
- 新增 `/api/v1/settings/embedding` 4 個端點
- 知識庫頁加「Embedding 設定」tab：服務狀態、模型下拉、topK/threshold slider、批次重嵌
- 模型維度鎖 1024，切換時提示「現有向量將失效」

### 2. Chat Provider 抽象 + 多輪追問
- `ChatProvider` 介面，實作 **Ollama + Google Gemini** 兩個 provider
- `generateReply` 改成 per-tenant：從 DB 讀 provider/model/temperature/maxTokens/system prompt
- **多輪歷史**：Ollama messages、Gemini contents 都會帶最近 10 則對話
- **多輪 Clarify**：KB 信心 < clarifyThreshold 時走 LLM 反問（不再直接 KB 回或 handoff）
- 達 maxAttempts 後自動 handoff
- 知識庫頁加「Chat & Prompt」tab：provider 切換、模型分組下拉、temperature/maxTokens、3 個 system prompt 編輯框 + clarify 設定
- `GEMINI_API_KEY` 走 `.env` 全域共用

### 3. Partner Ingest（Stanley 對接）
- `KmArticle` 新增 `externalDocId/Ver/Source/spec/importedAt` 欄位
- 新增 `KmArticleAttachment` model
- `POST /api/v1/knowledge/partner-ingest`（multipart/form-data，需 SUPERVISOR）
- Schema：DocID / Ver / VerCreatTime / AI_Q / AI_A / Source(容錯 Soruce typo) / Spec / IsAttached / Attached(多檔)
- Upsert by `(tenantId, externalDocId)`：Ver 高 → 覆寫 + cascade 刪舊附件 + 重算 embedding；Ver 同/低 → idempotent skip
- 附件走既有 `uploadFile()` 寫到 S3/MinIO `media/kb/<docId>/`
- `prepareArticleText` 納入 `spec` JSON 與附件檔名 → 語意搜尋能命中規格

### 4. 順手修
- `apps/api/src/index.ts` + `apps/workers/src/index.ts`：`dotenv.config` 提前到 imports 之前。原本 BullMQ 在 import 時讀空 `process.env.REDIS_URL` → fallback 6379 → workers 連不上 → KB autoreply 不會跑
- `docker-compose.yml`：postgres port `5432:5432` 改回 `5433:5432`（與 .env 對齊；本機 5432 已被另一 PG 佔用）
- `.gitignore` 加 `logs/`

## Test plan

本機已驗：
- [x] `pnpm build` 12/12 全綠
- [x] `pnpm --filter @open333crm/api exec tsc --noEmit` 0 errors
- [x] `pnpm --filter @open333crm/web exec tsc --noEmit` 0 errors
- [x] Embedding GET/PUT/health 端點
- [x] Chat GET/PUT/models/health 端點，實測 Gemini 2.5 Flash 跑情緒分析 confidence 0.99
- [x] `scripts/sim-inbound.sh "壞了怎辦"` → threshold=0.5 走 KB、threshold=0.7 走 clarify（兩種路徑都驗過）
- [x] `partner-ingest`：create / skip(idempotent) / update 三條路徑 + cascade 刪舊附件 + KB「電鍋 750W」搜得到 spec
- [x] MinIO `<tenantId>/media/kb/<docId>/` 看到實際附件

需要在 reviewer 端確認：
- [ ] CI build 通過
- [ ] 進 `/dashboard/knowledge` → 4 個 tab 都正常顯示
- [ ] DocID 1243 的範例文章在文章管理列表看得到「DocID 1243 · v1 · 📎 1」徽章

## Migration 注意

本 PR 動了 `TenantSettings` 與 `KmArticle` 的 schema，但**未加入 prisma migration 檔**（因為現有 DB 與 prisma migrations 目錄已有 drift，前手共識是用 `db push` / 手動 ALTER）。要 apply 到別的環境時請：

```sql
ALTER TABLE tenant_settings
  ADD COLUMN IF NOT EXISTS "embeddingBaseUrl" TEXT NOT NULL DEFAULT 'http://localhost:11434',
  ADD COLUMN IF NOT EXISTS "embeddingModel" TEXT NOT NULL DEFAULT 'bge-m3',
  ADD COLUMN IF NOT EXISTS "embeddingTopK" INTEGER NOT NULL DEFAULT 5,
  ADD COLUMN IF NOT EXISTS "embeddingThreshold" DOUBLE PRECISION NOT NULL DEFAULT 0.3,
  ADD COLUMN IF NOT EXISTS "chatProvider" TEXT NOT NULL DEFAULT 'ollama',
  ADD COLUMN IF NOT EXISTS "chatModel" TEXT NOT NULL DEFAULT 'qwen2.5:3b',
  ADD COLUMN IF NOT EXISTS "chatBaseUrl" TEXT NOT NULL DEFAULT 'http://localhost:11434',
  ADD COLUMN IF NOT EXISTS "chatTemperature" DOUBLE PRECISION NOT NULL DEFAULT 0.3,
  ADD COLUMN IF NOT EXISTS "chatMaxTokens" INTEGER NOT NULL DEFAULT 500,
  ADD COLUMN IF NOT EXISTS "chatSystemPrompt" TEXT NOT NULL DEFAULT '',
  ADD COLUMN IF NOT EXISTS "summarizeSystemPrompt" TEXT NOT NULL DEFAULT '',
  ADD COLUMN IF NOT EXISTS "clarifySystemPrompt" TEXT NOT NULL DEFAULT '',
  ADD COLUMN IF NOT EXISTS "clarifyThreshold" DOUBLE PRECISION NOT NULL DEFAULT 0.5,
  ADD COLUMN IF NOT EXISTS "clarifyMaxAttempts" INTEGER NOT NULL DEFAULT 2;

ALTER TABLE conversations ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'::jsonb;

ALTER TABLE km_articles
  ADD COLUMN IF NOT EXISTS "externalDocId" VARCHAR(64),
  ADD COLUMN IF NOT EXISTS "externalVer" INTEGER NOT NULL DEFAULT 0,
  ADD COLUMN IF NOT EXISTS "externalSource" TEXT,
  ADD COLUMN IF NOT EXISTS spec JSONB,
  ADD COLUMN IF NOT EXISTS "importedAt" TIMESTAMP(3);
CREATE UNIQUE INDEX IF NOT EXISTS km_articles_tenantId_externalDocId_key
  ON km_articles("tenantId", "externalDocId");

CREATE TABLE IF NOT EXISTS km_article_attachments (
  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
  "articleId"  UUID NOT NULL REFERENCES km_articles(id) ON DELETE CASCADE,
  filename    TEXT NOT NULL,
  "storageKey" TEXT NOT NULL,
  url         TEXT NOT NULL,
  "mimeType"   TEXT NOT NULL,
  "sizeBytes"  INTEGER NOT NULL,
  "createdAt"  TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
);
CREATE INDEX IF NOT EXISTS km_article_attachments_articleId_idx
  ON km_article_attachments("articleId");
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)