### PR TITLE
fix(db): 補上 PR #102 漏掉的 prisma migration（修 UAT 400 DATABASE_ERROR）

### DIFF
--- a/packages/database/prisma/migrations/20260506031323_embedding_chat_clarify_partner_ingest/migration.sql
+++ b/packages/database/prisma/migrations/20260506031323_embedding_chat_clarify_partner_ingest/migration.sql
@@ -1,0 +1,48 @@
+-- AlterTable
+ALTER TABLE "conversations" ADD COLUMN     "metadata" JSONB NOT NULL DEFAULT '{}';
+
+-- AlterTable
+ALTER TABLE "km_articles" ADD COLUMN     "externalDocId" VARCHAR(64),
+ADD COLUMN     "externalSource" TEXT,
+ADD COLUMN     "externalVer" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "importedAt" TIMESTAMP(3),
+ADD COLUMN     "spec" JSONB;
+
+-- AlterTable
+ALTER TABLE "tenant_settings" ADD COLUMN     "chatBaseUrl" TEXT NOT NULL DEFAULT 'http://localhost:11434',
+ADD COLUMN     "chatMaxTokens" INTEGER NOT NULL DEFAULT 500,
+ADD COLUMN     "chatModel" TEXT NOT NULL DEFAULT 'qwen2.5:3b',
+ADD COLUMN     "chatProvider" TEXT NOT NULL DEFAULT 'ollama',
+ADD COLUMN     "chatSystemPrompt" TEXT NOT NULL DEFAULT '',
+ADD COLUMN     "chatTemperature" DOUBLE PRECISION NOT NULL DEFAULT 0.3,
+ADD COLUMN     "clarifyMaxAttempts" INTEGER NOT NULL DEFAULT 2,
+ADD COLUMN     "clarifySystemPrompt" TEXT NOT NULL DEFAULT '',
+ADD COLUMN     "clarifyThreshold" DOUBLE PRECISION NOT NULL DEFAULT 0.5,
+ADD COLUMN     "embeddingBaseUrl" TEXT NOT NULL DEFAULT 'http://localhost:11434',
+ADD COLUMN     "embeddingModel" TEXT NOT NULL DEFAULT 'bge-m3',
+ADD COLUMN     "embeddingThreshold" DOUBLE PRECISION NOT NULL DEFAULT 0.3,
+ADD COLUMN     "embeddingTopK" INTEGER NOT NULL DEFAULT 5,
+ADD COLUMN     "summarizeSystemPrompt" TEXT NOT NULL DEFAULT '';
+
+-- CreateTable
+CREATE TABLE "km_article_attachments" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "articleId" UUID NOT NULL,
+    "filename" TEXT NOT NULL,
+    "storageKey" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "sizeBytes" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "km_article_attachments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "km_article_attachments_articleId_idx" ON "km_article_attachments"("articleId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "km_articles_tenantId_externalDocId_key" ON "km_articles"("tenantId", "externalDocId");
+
+-- AddForeignKey
+ALTER TABLE "km_article_attachments" ADD CONSTRAINT "km_article_attachments_articleId_fkey" FOREIGN KEY ("articleId") REFERENCES "km_articles"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
## Summary

PR #102 合併時 `prisma migrate diff` 產出的 migration 檔還沒 commit，導致正式環境 entrypoint 跑 `prisma migrate deploy` 時沒套用到新 schema：

```
GET /api/v1/knowledge → 400 DATABASE_ERROR
"The table public.km_article_attachments does not exist in the current database."
```

## Root cause

- PR #102 程式碼用了 `_count.attachments`、`spec`、`externalDocId` 等新欄位 select
- 但合併時 DB 沒對應結構（migration 檔在 PR #102 合併**之後**才產出）
- 此 PR 把 migration 檔加進 main

## What's in the migration

- `conversations.metadata` (Jsonb)
- `km_articles` 新增 `externalDocId / externalVer / externalSource / spec / importedAt` + unique index
- `km_article_attachments` 新表 + FK + index
- `tenant_settings` 新增 13 個 chat / embedding / clarify 欄位

全部欄位都有 default 值，不會擋既有資料。

## Verify locally

```
pnpm exec prisma migrate diff \
  --from-migrations ./prisma/migrations \
  --to-schema-datamodel ./prisma/schema.prisma \
  --shadow-database-url "postgresql://crm:crmpassword@localhost:5433/open333crm_shadow" \
  --exit-code
# → No difference detected.
```

## Deploy plan

合併後 UAT 重新 deploy，entrypoint 會自動跑 `prisma migrate deploy` 套用此 migration，knowledge / settings/chat 端點即恢復。

🤖 Generated with [Claude Code](https://claude.com/claude-code)