### PR TITLE
fix(nginx): client_max_body_size 25M 對齊 fastify multipart 限制

### DIFF
--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -31,6 +31,10 @@ server {
     ssl_protocols       TLSv1.2 TLSv1.3;
     ssl_ciphers         HIGH:!aNULL:!MD5;
 
+    # Allow up to 25MB request body — matches @fastify/multipart fileSize limit
+    # for KB article uploads / partner-ingest attachments.
+    client_max_body_size 25M;
+
     # API routes
     location /api/ {
         proxy_pass http://api_upstream;


### PR DESCRIPTION
## Summary

UAT 上傳知識庫文章 / partner-ingest 附件時報 413 (Request Entity Too Large)。原因：nginx 預設 \`client_max_body_size\` 是 **1MB**，但 fastify multipart 已開 **25MB**（apps/api/src/index.ts:82），稍微大一點的檔案就被 nginx 先擋。

## Change

\`nginx/nginx.conf.template\` 在 HTTPS server block 加：

\`\`\`nginx
client_max_body_size 25M;
\`\`\`

與 fastify 限制對齊。

## Test plan

- [ ] 合併後重 deploy UAT，nginx 容器啟動會帶新 template
- [ ] 上傳一個 5-10MB 的 PDF / 圖片 → 應成功（之前會 413）

> 也會直接 hot-patch UAT nginx（不等 deploy），long-term 靠這個 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)