### PR TITLE
fix(api): 設定 fastify bodyLimit 30MB 修上傳 413

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -64,6 +64,9 @@ export async function bootstrap() {
   const config = loadEnvConfig();
 
   const app = Fastify({
+    // 30MB top-level body limit. Must be ≥ multipart fileSize so the
+    // request isn't rejected before @fastify/multipart can stream-parse it.
+    bodyLimit: 30 * 1024 * 1024,
     logger: {
       level: 'info',
       transport:


### PR DESCRIPTION
## Summary

UAT 上傳文章報 413。先前以為是 nginx，實際 UAT 用的是 **Caddy**（預設無 body 限制）。真正擋住的是 **fastify 全域 bodyLimit 預設 1MB**。

\`@fastify/multipart\` 雖然配置 \`fileSize: 25MB\`，但 fastify 主體會先依 \`bodyLimit\` 拒絕整個 request。

## Change

\`apps/api/src/index.ts\` Fastify 建構時加：

\`\`\`ts
bodyLimit: 30 * 1024 * 1024,  // 30MB
\`\`\`

> 30MB > multipart fileSize 25MB，留給 multipart boundary 與其他欄位空間。

## Test plan

- [ ] 合併後重 deploy UAT
- [ ] 上傳 5-10MB PDF / 圖片 → 應成功（之前 413）

## Note

之前 PR #104（nginx 那個）已關閉撤回。

🤖 Generated with [Claude Code](https://claude.com/claude-code)