### PR TITLE
fix(knowledge): publish 改 fire-and-forget 嵌入，避免 504 超時

### DIFF
--- a/apps/api/src/modules/knowledge/knowledge.routes.ts
+++ b/apps/api/src/modules/knowledge/knowledge.routes.ts
@@ -209,9 +209,26 @@ export default async function knowledgeRoutes(fastify: FastifyInstance) {
   );
 
   // POST /api/v1/knowledge/bulk-embed — 重新向量化所有已發布文章
+  // Returns immediately with article count; embedding runs in the background
+  // to avoid Caddy gateway timeouts on cold-start Ollama (model loading +
+  // per-article inference can easily exceed 60s for any non-trivial KB).
   fastify.post('/bulk-embed', async (request, reply) => {
-    const result = await bulkReembed(fastify.prisma, request.agent.tenantId);
-    return reply.send(success(result));
+    const tenantId = request.agent.tenantId;
+    const total = await fastify.prisma.kmArticle.count({
+      where: { tenantId, status: 'PUBLISHED' },
+    });
+
+    bulkReembed(fastify.prisma, tenantId).catch((err) => {
+      fastify.log.error({ err }, '[Knowledge] Background bulk re-embed failed');
+    });
+
+    return reply.send(
+      success({
+        started: true,
+        total,
+        message: `已開始重新嵌入 ${total} 篇文章，請稍後刷新「服務狀態」查看進度。`,
+      }),
+    );
   });
 
   // GET /api/v1/knowledge/embedding-status — 嵌入服務健康檢查

--- a/apps/api/src/modules/knowledge/knowledge.service.ts
+++ b/apps/api/src/modules/knowledge/knowledge.service.ts
@@ -214,24 +214,25 @@ export async function publishArticle(prisma: PrismaClient, id: string, tenantId:
     throw new AppError('Article is already published', 'INVALID_STATE', 400);
   }
 
-  // Ensure embedding exists before publishing; generate if missing
+  // Update status FIRST so the HTTP response returns quickly. Embedding is
+  // a slow LLM call (Ollama pulls model into memory on first use, takes
+  // 30+ seconds and can trip Caddy's gateway timeout) so we fire-and-forget.
+  // Worst case: article shows as PUBLISHED but lacks embedding — operator
+  // can use "批次重新嵌入" to backfill.
+  const updated = await prisma.kmArticle.update({
+    where: { id },
+    data: { status: 'PUBLISHED' },
+  });
+
   const [embCheck] = await prisma.$queryRawUnsafe<{ has: boolean }[]>(
     `SELECT (embedding IS NOT NULL) AS has FROM km_articles WHERE id = $1::uuid`,
     id,
   );
   if (!embCheck?.has) {
-    try {
-      await embedArticle(prisma, id);
-    } catch (err) {
-      logger.error(`[Knowledge] Could not generate embedding for publish (${id}):`, err);
-      // Continue publishing even if embedding fails — not a blocker for POC
-    }
+    embedArticle(prisma, id).catch((err) => {
+      logger.error(`[Knowledge] Background embedding failed for ${id}:`, err);
+    });
   }
-
-  const updated = await prisma.kmArticle.update({
-    where: { id },
-    data: { status: 'PUBLISHED' },
-  });
 
   return updated;
 }

--- a/apps/web/src/components/knowledge/EmbeddingSettings.tsx
+++ b/apps/web/src/components/knowledge/EmbeddingSettings.tsx
@@ -58,7 +58,7 @@ export function EmbeddingSettings() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [reembedding, setReembedding] = useState(false);
-  const [reembedResult, setReembedResult] = useState<{ total: number; succeeded: number; failed: number } | null>(null);
+  const [reembedResult, setReembedResult] = useState<{ started: boolean; total: number; message: string } | null>(null);
   const [confirmModelChange, setConfirmModelChange] = useState<{ from: string; to: string } | null>(null);
   const [customModel, setCustomModel] = useState(false);
 
@@ -129,11 +129,12 @@ export function EmbeddingSettings() {
     setReembedding(true);
     setReembedResult(null);
     try {
-      const res = await api.post<{ data: { total: number; succeeded: number; failed: number } }>(
+      const res = await api.post<{ data: { started: boolean; total: number; message: string } }>(
         '/knowledge/bulk-embed',
       );
       setReembedResult(res.data.data);
-      // refresh stats
+      // Stats will update over time as background job progresses; refetch
+      // current snapshot so the user sees something change immediately.
       const refresh = await api.get<{ data: SettingsResponse }>('/settings/embedding');
       setStats(refresh.data.data.stats);
     } catch (err) {
@@ -347,7 +348,7 @@ export function EmbeddingSettings() {
           </Button>
           {reembedResult && (
             <span className="text-xs text-muted-foreground">
-              共 {reembedResult.total} 篇，成功 {reembedResult.succeeded}，失敗 {reembedResult.failed}
+              {reembedResult.message}
             </span>
           )}
         </div>


### PR DESCRIPTION
## Symptom

UAT 點「發布」文章 → 504 Gateway Time-out（Caddy 等不到 API 回應）。

## Root cause

\`publishArticle\`（apps/api/src/modules/knowledge/knowledge.service.ts）原本是同步等 \`embedArticle\` 完成才回應：

\`\`\`
1. 查文章
2. 沒有 embedding → await embedArticle(...)   ← 慢！
3. update status = PUBLISHED
4. 回應 HTTP
\`\`\`

UAT Ollama 第一次跑 bge-m3 要 model-load（剛 pull 的）+ 推論，加總超過 Caddy 預設 timeout，就 504。

## Fix

調換順序 + 改 fire-and-forget：

\`\`\`
1. 查文章
2. update status = PUBLISHED       ← 快
3. 回應 HTTP                       ← user 立刻看到結果
4. 背景跑 embedArticle（不等）
\`\`\`

跟 \`createArticle\` / \`batchImportArticles\` 既有 fire-and-forget pattern 一致。

## Test plan

- [ ] 合併後重 deploy UAT
- [ ] 點「發布」→ 應立刻成功（不再 504）
- [ ] 等幾秒，文章列表應出現 🧠 icon = embedding 完成
- [ ] 萬一 embedding 失敗（例：Ollama 掛掉），可去 Embedding 設定 tab 用「批次重新嵌入」補

🤖 Generated with [Claude Code](https://claude.com/claude-code)