### PR TITLE
feat(conversation): 對話結案功能（人工 + 不活躍 + CSAT 連動）

### DIFF
--- a/apps/api/src/events/event-bus.ts
+++ b/apps/api/src/events/event-bus.ts
@@ -9,6 +9,7 @@ export type AppEventName =
   | 'conversation.created'
   | 'conversation.updated'
   | 'conversation.assigned'
+  | 'conversation.closed'
   | 'case.created'
   | 'case.updated'
   | 'case.assigned'

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -58,6 +58,7 @@ import { setupAnalyticsScheduler } from './modules/analytics/analytics.scheduler
 import { setupBroadcastScheduler } from './modules/marketing/broadcast.scheduler.js';
 import { setupCsatScheduler } from './modules/csat/csat.scheduler.js';
 import { setupSlaWorker } from './modules/sla/sla.worker.js';
+import { setupInactivityCloseWorker } from './modules/conversation/inactivity-close.worker.js';
 import { registerChannelPlugin, linePlugin, fbPlugin, webchatPlugin } from '@open333crm/channel-plugins';
 
 export async function bootstrap() {
@@ -138,6 +139,7 @@ export async function bootstrap() {
   setupBroadcastScheduler(app.prisma, app.io);
   setupCsatScheduler(app.prisma, app.io);
   setupSlaWorker(app.prisma, app.io);
+  setupInactivityCloseWorker(app.prisma, app.io);
   setupCanvasWorker(app.prisma, app.io);
   setupCanvasScheduler(app.prisma);
   ensureBucket().catch((err) => app.log.warn({ err }, 'MinIO bucket init skipped'));

--- a/apps/api/src/modules/conversation/conversation.routes.ts
+++ b/apps/api/src/modules/conversation/conversation.routes.ts
@@ -7,6 +7,7 @@ import {
   getMessages,
   sendMessage,
   updateConversation,
+  closeConversation,
   handoffConversation,
 } from './conversation.service.js';
 import { createCaseFromConversation } from '../case/case.service.js';
@@ -206,6 +207,27 @@ export default async function conversationRoutes(fastify: FastifyInstance) {
     );
 
     return reply.status(201).send(success(message));
+  });
+
+  // POST /api/v1/conversations/:id/close - close conversation with optional reason
+  fastify.post<{ Params: { id: string } }>('/:id/close', async (request, reply) => {
+    const data = z.object({
+      reason: z.string().max(1000).optional(),
+    }).parse(request.body ?? {});
+
+    const conversation = await closeConversation(
+      fastify.prisma,
+      fastify.io,
+      request.params.id,
+      request.agent.tenantId,
+      {
+        reason: data.reason,
+        source: 'manual',
+        closedById: request.agent.id,
+      },
+    );
+
+    return reply.send(success(conversation));
   });
 
   // POST /api/v1/conversations/:id/handoff - handoff from bot to agent

--- a/apps/api/src/modules/conversation/conversation.service.ts
+++ b/apps/api/src/modules/conversation/conversation.service.ts
@@ -632,3 +632,80 @@ export async function updateConversation(
 
   return updated;
 }
+
+/**
+ * Close a conversation with optional reason.
+ *
+ * Sets status=CLOSED, persists `closeReason` + `closeSource` + `closedAt`
+ * into conversation.metadata (JSON), emits `conversation.updated` socket
+ * event, and publishes `conversation.closed` to the in-process event bus.
+ *
+ * Idempotent: closing an already-closed conversation is a no-op (returns
+ * existing row) so cron / CSAT / case-resolved cascades don't double-fire.
+ */
+export async function closeConversation(
+  prisma: PrismaClient,
+  io: SocketIOServer,
+  id: string,
+  tenantId: string,
+  options: {
+    reason?: string;
+    source: 'manual' | 'inactivity' | 'csat' | 'case_resolved';
+    closedById?: string;
+  },
+) {
+  const conversation = await prisma.conversation.findFirst({
+    where: { id, tenantId },
+  });
+  if (!conversation) {
+    throw new AppError('Conversation not found', 'NOT_FOUND', 404);
+  }
+  if (conversation.status === 'CLOSED') {
+    return conversation;
+  }
+
+  const existingMeta = (conversation.metadata ?? {}) as Record<string, unknown>;
+  const now = new Date();
+
+  const updated = await prisma.conversation.update({
+    where: { id },
+    data: {
+      status: 'CLOSED',
+      metadata: {
+        ...existingMeta,
+        closeReason: options.reason ?? null,
+        closeSource: options.source,
+        closedAt: now.toISOString(),
+        closedById: options.closedById ?? null,
+      } as Prisma.InputJsonValue,
+    },
+    include: {
+      contact: { select: { id: true, displayName: true, avatarUrl: true } },
+      assignedTo: { select: { id: true, name: true, avatarUrl: true } },
+    },
+  });
+
+  const wsPayload = {
+    id: updated.id,
+    status: updated.status,
+    assignedToId: updated.assignedToId,
+    unreadCount: updated.unreadCount,
+    lastMessageAt: updated.lastMessageAt?.toISOString() ?? null,
+  };
+  io.to(`conversation:${id}`).emit('conversation.updated', wsPayload);
+  io.to(`tenant:${tenantId}`).emit('conversation.updated', wsPayload);
+
+  eventBus.publish({
+    name: 'conversation.closed',
+    tenantId,
+    timestamp: now,
+    payload: {
+      conversationId: id,
+      source: options.source,
+      reason: options.reason ?? null,
+      closedById: options.closedById ?? null,
+    },
+  });
+
+  return updated;
+}

--- a/apps/api/src/modules/conversation/inactivity-close.worker.ts
+++ b/apps/api/src/modules/conversation/inactivity-close.worker.ts
@@ -1,0 +1,68 @@
+/**
+ * Inactivity Close Worker — periodically closes conversations that have been
+ * idle longer than the per-tenant `inactivityCloseHours` threshold.
+ *
+ * Polls every POLL_INTERVAL_MS, groups candidate conversations by tenant,
+ * uses each tenant's TenantSettings.inactivityCloseHours (default 72h).
+ * Skips conversations with status=CLOSED (idempotent) and empty
+ * lastMessageAt (not yet started).
+ */
+
+import type { PrismaClient } from '@prisma/client';
+import type { Server as SocketIOServer } from 'socket.io';
+import { logger } from '@open333crm/core';
+import { closeConversation } from './conversation.service.js';
+
+const POLL_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes (inactivity is hourly-scale)
+const STARTUP_DELAY_MS = 30_000;
+
+export function setupInactivityCloseWorker(prisma: PrismaClient, io: SocketIOServer) {
+  async function pollInactivity() {
+    try {
+      // Group by tenant so each tenant's threshold applies independently.
+      const tenantSettings = await prisma.tenantSettings.findMany({
+        select: { tenantId: true, inactivityCloseHours: true },
+      });
+
+      let closedCount = 0;
+      for (const settings of tenantSettings) {
+        const hours = settings.inactivityCloseHours;
+        if (!Number.isFinite(hours) || hours <= 0) continue; // disabled
+
+        const cutoff = new Date(Date.now() - hours * 60 * 60 * 1000);
+
+        const candidates = await prisma.conversation.findMany({
+          where: {
+            tenantId: settings.tenantId,
+            status: { not: 'CLOSED' },
+            lastMessageAt: { not: null, lt: cutoff },
+          },
+          select: { id: true },
+        });
+
+        for (const c of candidates) {
+          try {
+            await closeConversation(prisma, io, c.id, settings.tenantId, {
+              source: 'inactivity',
+              reason: `Auto-closed after ${hours}h of inactivity`,
+            });
+            closedCount++;
+          } catch (err) {
+            logger.error(`[InactivityCloseWorker] Failed to close ${c.id}:`, err);
+          }
+        }
+      }
+
+      if (closedCount > 0) {
+        logger.info(`[InactivityCloseWorker] Closed ${closedCount} inactive conversations`);
+      }
+    } catch (err) {
+      logger.error('[InactivityCloseWorker] Poll error:', err);
+    }
+  }
+
+  setInterval(pollInactivity, POLL_INTERVAL_MS);
+  setTimeout(pollInactivity, STARTUP_DELAY_MS);
+
+  logger.info('[InactivityCloseWorker] Started — polling every 5min for inactive conversations');
+}

--- a/apps/api/src/modules/csat/csat.scheduler.ts
+++ b/apps/api/src/modules/csat/csat.scheduler.ts
@@ -1,6 +1,7 @@
 import type { PrismaClient } from '@prisma/client';
 import type { Server as SocketIOServer } from 'socket.io';
 import { sendCsatSurvey } from './csat.service.js';
+import { closeConversation } from '../conversation/conversation.service.js';
 import { eventBus } from '../../events/event-bus.js';
 import { logger } from '@open333crm/core';
 
@@ -97,6 +98,22 @@ export function setupCsatScheduler(prisma: PrismaClient, io: SocketIOServer) {
             priority: c.priority,
             assigneeId: c.assigneeId,
           });
+
+          // Cascade: close the linked conversation too (if any). Idempotent
+          // — closeConversation returns early if already CLOSED.
+          if (c.conversationId) {
+            try {
+              await closeConversation(prisma, io, c.conversationId, c.tenantId, {
+                source: 'csat',
+                reason: `CSAT 未回覆，自動結案 (${AUTO_CLOSE_HOURS}h)`,
+              });
+            } catch (err) {
+              logger.error(
+                `[CsatScheduler] Failed to close conversation ${c.conversationId} after case ${c.id} auto-close:`,
+                err,
+              );
+            }
+          }
 
           logger.info(`[CsatScheduler] Auto-closed case ${c.id} (no CSAT response after ${AUTO_CLOSE_HOURS}h)`);
         } catch (err) {

--- a/apps/web/src/components/inbox/ChatWindow.tsx
+++ b/apps/web/src/components/inbox/ChatWindow.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef, useState, useCallback } from 'react';
-import { Loader2, Lightbulb } from 'lucide-react';
+import { Loader2, Lightbulb, XCircle } from 'lucide-react';
 import useSWR, { mutate as globalMutate } from 'swr';
 import { useMessages } from '@/hooks/useMessages';
 import { MessageBubble } from './MessageBubble';
@@ -14,6 +14,14 @@ import { ChannelBadge } from '@/components/shared/ChannelBadge';
 import { EmptyState } from '@/components/shared/EmptyState';
 import { Select } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
 import api from '@/lib/api';
 import { MessageSquare } from 'lucide-react';
 
@@ -42,6 +50,9 @@ export function ChatWindow({ conversation, onShowAiSuggest, showAiSuggest }: Cha
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [templatePickerOpen, setTemplatePickerOpen] = useState(false);
   const [templateText, setTemplateText] = useState<string | null>(null);
+  const [closeDialogOpen, setCloseDialogOpen] = useState(false);
+  const [closeReason, setCloseReason] = useState('');
+  const [closing, setClosing] = useState(false);
 
   // Agent list
   const { data: agentsData } = useSWR('/agents', (url: string) =>
@@ -86,6 +97,25 @@ export function ChatWindow({ conversation, onShowAiSuggest, showAiSuggest }: Cha
       globalMutate(`/conversations/${conversation.id}`);
     } catch (err) {
       console.error('Handoff failed:', err);
+    }
+  };
+
+  const handleCloseConfirm = async () => {
+    if (!conversation) return;
+    setClosing(true);
+    try {
+      const body: { reason?: string } = {};
+      const trimmed = closeReason.trim();
+      if (trimmed) body.reason = trimmed;
+      await api.post(`/conversations/${conversation.id}/close`, body);
+      setCloseDialogOpen(false);
+      setCloseReason('');
+      globalMutate(`/conversations/${conversation.id}`);
+    } catch (err) {
+      console.error('Close conversation failed:', err);
+      alert('結案失敗，請稍後再試');
+    } finally {
+      setClosing(false);
     }
   };
 
@@ -185,6 +215,18 @@ export function ChatWindow({ conversation, onShowAiSuggest, showAiSuggest }: Cha
               <Lightbulb className="h-4 w-4" />
             </Button>
           )}
+          {!isClosed && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 gap-1 text-destructive hover:bg-destructive/10 hover:text-destructive"
+              onClick={() => setCloseDialogOpen(true)}
+              title="結案此對話"
+            >
+              <XCircle className="h-4 w-4" />
+              <span className="text-xs">結案</span>
+            </Button>
+          )}
           <Select
             className="h-8 w-32 text-xs"
             options={statusOptions}
@@ -252,6 +294,60 @@ export function ChatWindow({ conversation, onShowAiSuggest, showAiSuggest }: Cha
         onSelect={handleTemplateSelect}
         channelType={conversation.channelType}
       />
+
+      {/* Close Conversation Dialog */}
+      <Dialog
+        open={closeDialogOpen}
+        onOpenChange={(open) => {
+          if (!closing) setCloseDialogOpen(open);
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>結案此對話</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3 text-sm">
+            <p className="text-muted-foreground">
+              結案後此對話將從 Inbox 列表移出。客戶若再次傳訊將自動開新對話。
+            </p>
+            <div>
+              <label className="mb-1.5 block text-xs font-medium">
+                結案原因（選填）
+              </label>
+              <Textarea
+                value={closeReason}
+                onChange={(e) => setCloseReason(e.target.value)}
+                placeholder="例：問題已解決 / 客戶未回覆 / 重複對話..."
+                rows={3}
+                disabled={closing}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setCloseDialogOpen(false)}
+              disabled={closing}
+            >
+              取消
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleCloseConfirm}
+              disabled={closing}
+            >
+              {closing ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  結案中…
+                </>
+              ) : (
+                '確認結案'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/packages/database/prisma/migrations/20260506065518_inactivity_close_hours/migration.sql
+++ b/packages/database/prisma/migrations/20260506065518_inactivity_close_hours/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "tenant_settings" ADD COLUMN     "inactivityCloseHours" INTEGER NOT NULL DEFAULT 72;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -906,6 +906,7 @@ model TenantSettings {
   clarifySystemPrompt    String   @default("")
   clarifyThreshold       Float    @default(0.5)
   clarifyMaxAttempts     Int      @default(2)
+  inactivityCloseHours   Int      @default(72)
   createdAt              DateTime @default(now())
   updatedAt              DateTime @updatedAt
 


### PR DESCRIPTION
## Summary

新增 3 個結案觸發點。所有路徑都走同一個 \`closeConversation()\` service，確保 metadata、socket、eventBus 行為一致。

### 1. 人工結案（按鈕）
- Inbox ChatWindow header 加紅色「結案」按鈕
- 點擊跳出 dialog，可選填結案原因
- POST \`/api/v1/conversations/:id/close\` body: \`{ reason?: string }\`

### 2. 不活躍逾時自動結案
- 新增 \`InactivityCloseWorker\`，每 5 分鐘輪詢
- 超過 \`TenantSettings.inactivityCloseHours\`（default **72h**）沒新訊息的對話自動結案
- 設為 0 或負值 = 該 tenant 停用此功能

### 3. CSAT 連動
- 既有 CSAT scheduler 自動關 case 時，連動關閉關聯 conversation
- 避免遺留對話卡在 inbox

## Schema

\`TenantSettings.inactivityCloseHours\` (Int, default 72) — 含 prisma migration。

## API

\`POST /api/v1/conversations/:id/close\`
- body: \`{ reason?: string }\` (max 1000 chars)
- 200: 完整 conversation 物件
- 404: 找不到
- idempotent — 已 CLOSED 對話直接 return（不重複觸發 event）

## Metadata schema

結案後 conversation.metadata 會包含：
\`\`\`json
{
  "closeReason": "用戶填寫或 worker 自動產生 / null",
  "closeSource": "manual | inactivity | csat | case_resolved",
  "closedAt": "ISO timestamp",
  "closedById": "agent UUID 或 null（worker 觸發時為 null）"
}
\`\`\`

## Events

新增 \`AppEventName: 'conversation.closed'\`，供未來 notification / analytics 訂閱。

## 結案後行為

- 對話從 inbox「未結案」tab 消失（service 既有 \`status: !CLOSED\` filter）
- 客戶再傳訊會在 webhook.service 自動開新對話（既有 logic 用 \`status: { not: 'CLOSED' }\` 找舊對話，找不到就建新 BOT_HANDLED 對話）

## Test plan

- [x] tsc --noEmit api+web → 0 errors
- [x] pnpm build → 12/12 全綠
- [ ] 部署後：Inbox 點「結案」→ 對話從列表消失
- [ ] 客戶再傳 LINE 訊息 → 開新對話、Bot 從頭接
- [ ] 不活躍 worker：把某對話的 lastMessageAt 改成 73h 前 → 等 5 分鐘 → 應自動 CLOSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)