### PR TITLE
fix(gemini): 關閉 thinking mode 避免回覆被截斷 (MAX_TOKENS)

### DIFF
--- a/apps/api/src/modules/ai/providers/gemini.provider.ts
+++ b/apps/api/src/modules/ai/providers/gemini.provider.ts
@@ -71,6 +71,11 @@ export const GeminiChatProvider: ChatProvider = {
           generationConfig: {
             temperature: opts.temperature,
             maxOutputTokens: opts.maxTokens,
+            // Gemini 2.5 系列預設啟用 thinking mode，會把大量 token 花在內
+            // 部推理，可見輸出常被截斷（觀察到 maxOutputTokens=500 但只回
+            // 30 字就斷）。客服回覆不需要鏈式推理，明確關閉 thinking 確
+            // 保 maxOutputTokens 全部留給輸出。
+            thinkingConfig: { thinkingBudget: 0 },
           },
         }),
         signal: controller.signal,
@@ -82,14 +87,33 @@ export const GeminiChatProvider: ChatProvider = {
       }
 
       const data = (await response.json()) as {
-        candidates?: { content?: { parts?: { text?: string }[] } }[];
+        candidates?: {
+          content?: { parts?: { text?: string }[] };
+          finishReason?: string;
+        }[];
+        usageMetadata?: {
+          promptTokenCount?: number;
+          candidatesTokenCount?: number;
+          thoughtsTokenCount?: number;
+          totalTokenCount?: number;
+        };
       };
 
-      const text = data.candidates?.[0]?.content?.parts
+      const candidate = data.candidates?.[0];
+      const text = candidate?.content?.parts
         ?.map((p) => p.text ?? '')
         .join('')
         .trim();
 
+      // MAX_TOKENS = output truncated. Throw with diagnostic info so
+      // operators see why the user got a half sentence (raise chatMaxTokens
+      // or keep thinking disabled).
+      if (candidate?.finishReason === 'MAX_TOKENS') {
+        const usage = data.usageMetadata ?? {};
+        throw new Error(
+          `Gemini reply truncated by MAX_TOKENS (output=${usage.candidatesTokenCount ?? '?'} thoughts=${usage.thoughtsTokenCount ?? 0} max=${opts.maxTokens}). Increase chatMaxTokens or ensure thinkingConfig.thinkingBudget=0.`,
+        );
+      }
       if (!text) throw new Error('Gemini returned empty response');
       return text;
     } finally {


### PR DESCRIPTION
## Symptom

UAT 觀察到 Gemini 2.5 Flash 客服回覆只講 30+ 個中文字就斷（句子明顯沒講完）。

\`\`\`
"您好，聽到您的電鍋燒起來甚至家裡也著火了，這是一個非常"   ← 斷在「非常」
"您好，聽到您的電鍋燒起來甚至家裡也著火了，這是一個"     ← 斷在「一個」
\`\`\`

\`chatMaxTokens=500\` 應該夠中文 200+ 字才對。

## Root cause

Gemini 2.5 系列預設啟用 **thinking mode**，會在 \`generateContent\` 內部花大量 token 做鏈式推理（response.usageMetadata.thoughtsTokenCount），這部分**也計入** \`maxOutputTokens\` 額度。可見輸出 (candidatesTokenCount) 被擠壓，常達 \`finishReason=MAX_TOKENS\` 提早停。

## Fix

\`apps/api/src/modules/ai/providers/gemini.provider.ts\`

1. \`generationConfig.thinkingConfig.thinkingBudget = 0\` — 客服回覆不需要鏈式推理，把 maxOutputTokens 全部留給輸出
2. 解析 \`finishReason\`；若為 MAX_TOKENS 拋出包含 usageMetadata 的明確錯誤訊息（之前只看到回覆被截但無從 debug）

## Test plan

- [x] tsc --noEmit api → 0 errors
- [ ] 部署後在 UAT 用 LINE 對話測試 → 應講完整句不再被截
- [ ] 萬一 maxTokens 真的不夠（很長的回覆），現在會看到明確錯誤而不是默默截斷

🤖 Generated with [Claude Code](https://claude.com/claude-code)