### PR TITLE
feat(auth): Partner API Keys for /knowledge/partner-ingest

### DIFF
--- a/apps/api/src/modules/auth/partner-api-key.service.ts
+++ b/apps/api/src/modules/auth/partner-api-key.service.ts
@@ -1,0 +1,134 @@
+/**
+ * Partner API Key service
+ *
+ * Long-lived API keys for external partners to call /knowledge/partner-ingest
+ * without managing JWT refresh. Stored as bcrypt hash; raw key shown only on
+ * creation. List view shows prefix + last 4 chars for identification.
+ */
+
+import { randomBytes } from 'node:crypto';
+import type { PrismaClient, PartnerApiKey } from '@prisma/client';
+import { hashPassword, verifyPassword } from '../../shared/utils/password.js';
+import { logger } from '@open333crm/core';
+
+const KEY_PREFIX = 'pk_';
+const KEY_RANDOM_BYTES = 32; // → 64 hex chars
+// keyPrefix col stores the leading visible identifier ("pk_" + first 5 hex);
+// keySuffix col stores last 4 hex. Together: "pk_a1b2c…f9e0"
+
+export interface CreateApiKeyInput {
+  tenantId: string;
+  createdById: string;
+  name: string;
+  expiresAt?: Date | null;
+}
+
+export interface CreateApiKeyResult {
+  /** Raw key — only shown once at creation. Never persisted. */
+  key: string;
+  apiKey: PartnerApiKey;
+}
+
+/**
+ * Generate a new API key, hash + persist, return both the raw key (one-time)
+ * and the row.
+ */
+export async function createPartnerApiKey(
+  prisma: PrismaClient,
+  input: CreateApiKeyInput,
+): Promise<CreateApiKeyResult> {
+  const random = randomBytes(KEY_RANDOM_BYTES).toString('hex');
+  const rawKey = `${KEY_PREFIX}${random}`;
+  const keyHash = await hashPassword(rawKey);
+
+  // For display: "pk_xxxxx" (prefix + first 5 hex chars)
+  const keyPrefix = `${KEY_PREFIX}${random.slice(0, 5)}`;
+  const keySuffix = random.slice(-4);
+
+  const apiKey = await prisma.partnerApiKey.create({
+    data: {
+      tenantId: input.tenantId,
+      createdById: input.createdById,
+      name: input.name,
+      keyHash,
+      keyPrefix,
+      keySuffix,
+      expiresAt: input.expiresAt ?? null,
+    },
+  });
+
+  return { key: rawKey, apiKey };
+}
+
+export async function listPartnerApiKeys(
+  prisma: PrismaClient,
+  tenantId: string,
+): Promise<PartnerApiKey[]> {
+  return prisma.partnerApiKey.findMany({
+    where: { tenantId },
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+export async function revokePartnerApiKey(
+  prisma: PrismaClient,
+  tenantId: string,
+  id: string,
+): Promise<void> {
+  await prisma.partnerApiKey.update({
+    where: { id, tenantId },
+    data: { isActive: false },
+  });
+}
+
+export type VerifyResult =
+  | { ok: true; apiKey: PartnerApiKey }
+  | { ok: false; reason: string };
+
+/**
+ * Verify a raw key from request header.
+ *
+ * Approach: extract prefix to narrow candidates (so we only bcrypt.compare
+ * against keys with matching prefix), then bcrypt-verify against each
+ * candidate's hash. With prefix index this is O(1) DB lookup + tiny bcrypt
+ * batch (almost always exactly 1 candidate).
+ */
+export async function verifyPartnerApiKey(
+  prisma: PrismaClient,
+  rawKey: string,
+): Promise<VerifyResult> {
+  if (!rawKey.startsWith(KEY_PREFIX)) {
+    return { ok: false, reason: 'Malformed API key' };
+  }
+  const random = rawKey.slice(KEY_PREFIX.length);
+  if (random.length < 9) {
+    return { ok: false, reason: 'Malformed API key' };
+  }
+
+  const keyPrefix = `${KEY_PREFIX}${random.slice(0, 5)}`;
+
+  const candidates = await prisma.partnerApiKey.findMany({
+    where: { keyPrefix, isActive: true },
+  });
+
+  for (const cand of candidates) {
+    const matches = await verifyPassword(rawKey, cand.keyHash);
+    if (!matches) continue;
+
+    // Expiry check
+    if (cand.expiresAt && cand.expiresAt.getTime() < Date.now()) {
+      return { ok: false, reason: 'API key expired' };
+    }
+
+    // Touch lastUsedAt (fire-and-forget; don't block request on this)
+    prisma.partnerApiKey
+      .update({ where: { id: cand.id }, data: { lastUsedAt: new Date() } })
+      .catch((err) =>
+        logger.warn(`[PartnerApiKey] Failed to touch lastUsedAt for ${cand.id}: ${(err as Error).message}`),
+      );
+
+    return { ok: true, apiKey: cand };
+  }
+
+  return { ok: false, reason: 'Invalid API key' };
+}

--- a/apps/api/src/modules/knowledge/knowledge.routes.ts
+++ b/apps/api/src/modules/knowledge/knowledge.routes.ts
@@ -59,8 +59,15 @@ const importSchema = z.object({
 });
 
 export default async function knowledgeRoutes(fastify: FastifyInstance) {
-  // All routes require authentication
-  fastify.addHook('preHandler', fastify.authenticate);
+  // Auth: most routes require agent JWT; partner-ingest additionally accepts
+  // long-lived Partner API keys (Authorization: Bearer pk_...).
+  fastify.addHook('preHandler', async (request, reply) => {
+    if (request.url.includes('/partner-ingest')) {
+      await fastify.authenticateJwtOrPartnerKey(request, reply);
+    } else {
+      await fastify.authenticate(request, reply);
+    }
+  });
 
   // GET /api/v1/knowledge — 文章列表
   fastify.get('/', async (request, reply) => {

--- a/apps/api/src/modules/settings/settings.routes.ts
+++ b/apps/api/src/modules/settings/settings.routes.ts
@@ -18,6 +18,11 @@ import {
   getProviderList,
 } from './chat-settings.service.js';
 import {
+  createPartnerApiKey,
+  listPartnerApiKeys,
+  revokePartnerApiKey,
+} from '../auth/partner-api-key.service.js';
+import {
   CRM_REPLY_SYSTEM_PROMPT,
   SUMMARIZE_SYSTEM_PROMPT,
   CLARIFY_SYSTEM_PROMPT,
@@ -156,7 +161,66 @@ export default async function settingsRoutes(fastify: FastifyInstance) {
     const health = await checkChatHealth(settings.provider, settings.model, settings.baseUrl);
     return reply.send(success(health));
   });
+
+  // ─── Partner API Keys ────────────────────────────────────────────────────
+  // GET /api/v1/settings/api-keys — list (masked)
+  fastify.get('/api-keys', async (request, reply) => {
+    const rows = await listPartnerApiKeys(fastify.prisma, request.agent.tenantId);
+    return reply.send(
+      success(
+        rows.map((r) => ({
+          id: r.id,
+          name: r.name,
+          masked: `${r.keyPrefix}…${r.keySuffix}`,
+          isActive: r.isActive,
+          expiresAt: r.expiresAt,
+          lastUsedAt: r.lastUsedAt,
+          createdAt: r.createdAt,
+        })),
+      ),
+    );
+  });
+
+  // POST /api/v1/settings/api-keys — create (returns raw key once)
+  fastify.post('/api-keys', async (request, reply) => {
+    const body = createApiKeySchema.parse(request.body);
+    const expiresAt = body.expiresInDays
+      ? new Date(Date.now() + body.expiresInDays * 24 * 60 * 60 * 1000)
+      : null;
+
+    const result = await createPartnerApiKey(fastify.prisma, {
+      tenantId: request.agent.tenantId,
+      createdById: request.agent.id,
+      name: body.name,
+      expiresAt,
+    });
+
+    return reply.status(201).send(
+      success({
+        // The raw key is only available here. Store it on the client side
+        // immediately — the server will never return it again.
+        key: result.key,
+        id: result.apiKey.id,
+        name: result.apiKey.name,
+        masked: `${result.apiKey.keyPrefix}…${result.apiKey.keySuffix}`,
+        expiresAt: result.apiKey.expiresAt,
+        createdAt: result.apiKey.createdAt,
+      }),
+    );
+  });
+
+  // DELETE /api/v1/settings/api-keys/:id — revoke (soft-delete; isActive=false)
+  fastify.delete<{ Params: { id: string } }>('/api-keys/:id', async (request, reply) => {
+    await revokePartnerApiKey(fastify.prisma, request.agent.tenantId, request.params.id);
+    return reply.send(success({ revoked: true }));
+  });
 }
+
+const createApiKeySchema = z.object({
+  name: z.string().min(1).max(100),
+  // null / undefined / 0 → never expires
+  expiresInDays: z.number().int().positive().nullable().optional(),
+});
 
 const embeddingSettingsSchema = z.object({
   baseUrl: z.string().url().optional(),

--- a/apps/api/src/plugins/auth.plugin.ts
+++ b/apps/api/src/plugins/auth.plugin.ts
@@ -2,16 +2,25 @@ import fp from 'fastify-plugin';
 import fastifyJwt from '@fastify/jwt';
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { getConfig } from '../config/env.js';
+import { verifyPartnerApiKey } from '../modules/auth/partner-api-key.service.js';
 
 export interface AgentPayload {
   id: string;
   tenantId: string;
   role: string;
+  /** Set when authenticated via partner API key (not a real human agent). */
+  isPartnerKey?: boolean;
+  /** PartnerApiKey row id, only present when isPartnerKey=true */
+  apiKeyId?: string;
 }
 
 declare module 'fastify' {
   interface FastifyInstance {
     authenticate: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+    authenticateJwtOrPartnerKey: (
+      request: FastifyRequest,
+      reply: FastifyReply,
+    ) => Promise<void>;
   }
   interface FastifyRequest {
     agent: AgentPayload;
@@ -63,6 +72,58 @@ async function authPlugin(fastify: FastifyInstance) {
       });
     }
   });
+
+  /**
+   * Try Partner API key first (Authorization: Bearer pk_...), fall back to
+   * agent JWT. Used by endpoints that accept either form (e.g. partner-ingest).
+   *
+   * On success, attaches `request.agent` with either real agent payload or
+   * a synthetic agent for API key (role=SUPERVISOR, isPartnerKey=true,
+   * apiKeyId set).
+   */
+  fastify.decorate(
+    'authenticateJwtOrPartnerKey',
+    async function (request: FastifyRequest, reply: FastifyReply) {
+      const auth = request.headers.authorization ?? '';
+      const m = auth.match(/^Bearer\s+(.+)$/i);
+      const token = m?.[1];
+
+      if (token && token.startsWith('pk_')) {
+        const result = await verifyPartnerApiKey(fastify.prisma, token);
+        if (!result.ok) {
+          reply.status(401).send({
+            success: false,
+            error: { code: 'UNAUTHORIZED', message: result.reason ?? 'Invalid API key' },
+          });
+          return;
+        }
+        request.agent = {
+          id: result.apiKey.createdById,
+          tenantId: result.apiKey.tenantId,
+          role: 'SUPERVISOR',
+          isPartnerKey: true,
+          apiKeyId: result.apiKey.id,
+        };
+        return;
+      }
+
+      // Fall back to JWT
+      try {
+        await request.jwtVerify();
+        const payload = request.user;
+        request.agent = {
+          id: payload.agentId,
+          tenantId: payload.tenantId,
+          role: payload.role,
+        };
+      } catch {
+        reply.status(401).send({
+          success: false,
+          error: { code: 'UNAUTHORIZED', message: 'Invalid or expired token' },
+        });
+      }
+    },
+  );
 }
 
 export default fp(authPlugin, {

--- a/apps/web/src/app/dashboard/settings/page.tsx
+++ b/apps/web/src/app/dashboard/settings/page.tsx
@@ -8,6 +8,7 @@ import { TagManagement } from '@/components/settings/TagManagement';
 import { SlaManagement } from '@/components/settings/SlaManagement';
 import { GeneralSettings } from '@/components/settings/GeneralSettings';
 import { OfficeHoursSettings } from '@/components/settings/OfficeHoursSettings';
+import { ApiKeyManagement } from '@/components/settings/ApiKeyManagement';
 
 const SETTINGS_TABS = [
   { key: 'channels', label: '渠道管理' },
@@ -15,6 +16,7 @@ const SETTINGS_TABS = [
   { key: 'tags', label: '標籤管理' },
   { key: 'sla', label: 'SLA 政策' },
   { key: 'office-hours', label: '營業時間' },
+  { key: 'api-keys', label: 'API 金鑰' },
   { key: 'general', label: '一般設定' },
 ] as const;
 
@@ -55,6 +57,7 @@ export default function SettingsPage() {
           {activeTab === 'tags' && <TagManagement />}
           {activeTab === 'sla' && <SlaManagement />}
           {activeTab === 'office-hours' && <OfficeHoursSettings />}
+          {activeTab === 'api-keys' && <ApiKeyManagement />}
           {activeTab === 'general' && <GeneralSettings />}
         </div>
       </div>

--- a/apps/web/src/components/settings/ApiKeyManagement.tsx
+++ b/apps/web/src/components/settings/ApiKeyManagement.tsx
@@ -1,0 +1,365 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { format } from 'date-fns';
+import { Plus, Loader2, Copy, Check, Trash2, Key } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select } from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import api from '@/lib/api';
+
+interface ApiKey {
+  id: string;
+  name: string;
+  masked: string;
+  isActive: boolean;
+  expiresAt: string | null;
+  lastUsedAt: string | null;
+  createdAt: string;
+}
+
+interface CreatedApiKey {
+  id: string;
+  name: string;
+  key: string;        // raw key — only shown once
+  masked: string;
+  expiresAt: string | null;
+  createdAt: string;
+}
+
+const EXPIRY_OPTIONS = [
+  { value: '0', label: '永不過期' },
+  { value: '30', label: '30 天' },
+  { value: '90', label: '90 天' },
+  { value: '180', label: '180 天' },
+  { value: '365', label: '1 年' },
+];
+
+export function ApiKeyManagement() {
+  const [keys, setKeys] = useState<ApiKey[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createdKey, setCreatedKey] = useState<CreatedApiKey | null>(null);
+
+  const fetchKeys = useCallback(async () => {
+    try {
+      const res = await api.get<{ data: ApiKey[] }>('/settings/api-keys');
+      setKeys(res.data.data);
+    } catch (err) {
+      console.error('Failed to fetch API keys:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchKeys();
+  }, [fetchKeys]);
+
+  const handleRevoke = async (id: string, name: string) => {
+    if (!confirm(`確定要撤銷「${name}」這把金鑰嗎？撤銷後使用此金鑰的合作方會立即無法呼叫 API。`)) return;
+    try {
+      await api.delete(`/settings/api-keys/${id}`);
+      fetchKeys();
+    } catch (err: unknown) {
+      const e = err as { response?: { data?: { error?: { message?: string } } } };
+      alert(e.response?.data?.error?.message || '撤銷失敗');
+    }
+  };
+
+  return (
+    <div className="space-y-6 max-w-4xl">
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Partner API 金鑰</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            提供給合作方（產品 / 行銷 / 客服）長期使用的 API 金鑰，僅可呼叫 <code className="rounded bg-muted px-1.5 py-0.5 text-xs">POST /knowledge/partner-ingest</code> 推送知識庫文件。
+          </p>
+        </div>
+        <Button onClick={() => setCreateOpen(true)}>
+          <Plus className="mr-2 h-4 w-4" />
+          建立金鑰
+        </Button>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : keys.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-12 text-center">
+          <Key className="mb-3 h-10 w-10 text-muted-foreground" />
+          <p className="text-sm font-medium">尚未建立任何金鑰</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            點「建立金鑰」開始為合作方產生第一把
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b bg-muted/50 text-left text-xs uppercase text-muted-foreground">
+                <th className="px-4 py-2.5 font-medium">名稱</th>
+                <th className="px-4 py-2.5 font-medium">金鑰</th>
+                <th className="px-4 py-2.5 font-medium">狀態</th>
+                <th className="px-4 py-2.5 font-medium">最後使用</th>
+                <th className="px-4 py-2.5 font-medium">過期時間</th>
+                <th className="px-4 py-2.5 font-medium">建立時間</th>
+                <th className="px-4 py-2.5 font-medium">操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {keys.map((k) => (
+                <tr key={k.id} className="border-b transition-colors hover:bg-muted/30">
+                  <td className="px-4 py-3 text-sm font-medium">{k.name}</td>
+                  <td className="px-4 py-3">
+                    <code className="rounded bg-muted px-1.5 py-0.5 text-xs">{k.masked}</code>
+                  </td>
+                  <td className="px-4 py-3">
+                    {k.isActive ? (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
+                        啟用中
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">
+                        已撤銷
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-xs text-muted-foreground">
+                    {k.lastUsedAt ? format(new Date(k.lastUsedAt), 'yyyy-MM-dd HH:mm') : '從未使用'}
+                  </td>
+                  <td className="px-4 py-3 text-xs text-muted-foreground">
+                    {k.expiresAt ? format(new Date(k.expiresAt), 'yyyy-MM-dd') : '永不過期'}
+                  </td>
+                  <td className="px-4 py-3 text-xs text-muted-foreground">
+                    {format(new Date(k.createdAt), 'yyyy-MM-dd HH:mm')}
+                  </td>
+                  <td className="px-4 py-3">
+                    {k.isActive && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleRevoke(k.id, k.name)}
+                        className="text-destructive hover:text-destructive"
+                        title="撤銷"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <CreateApiKeyDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onCreated={(created) => {
+          setCreateOpen(false);
+          setCreatedKey(created);
+          fetchKeys();
+        }}
+      />
+
+      <CreatedApiKeyDialog
+        keyData={createdKey}
+        onOpenChange={(open) => {
+          if (!open) setCreatedKey(null);
+        }}
+      />
+    </div>
+  );
+}
+
+// ───────────────────────────────────────────────────────────
+
+function CreateApiKeyDialog({
+  open,
+  onOpenChange,
+  onCreated,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: (created: CreatedApiKey) => void;
+}) {
+  const [name, setName] = useState('');
+  const [expiry, setExpiry] = useState('0');
+  const [creating, setCreating] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setName('');
+      setExpiry('0');
+    }
+  }, [open]);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    setCreating(true);
+    try {
+      const days = parseInt(expiry, 10);
+      const body: { name: string; expiresInDays?: number | null } = {
+        name: name.trim(),
+      };
+      if (days > 0) body.expiresInDays = days;
+
+      const res = await api.post<{ data: CreatedApiKey }>('/settings/api-keys', body);
+      onCreated(res.data.data);
+    } catch (err: unknown) {
+      const e = err as { response?: { data?: { error?: { message?: string } } } };
+      alert(e.response?.data?.error?.message || '建立失敗');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !creating && onOpenChange(o)}>
+      <DialogContent className="sm:max-w-md">
+        <form onSubmit={handleCreate}>
+          <DialogHeader>
+            <DialogTitle>建立 API 金鑰</DialogTitle>
+          </DialogHeader>
+
+          <div className="mt-4 space-y-4">
+            <div>
+              <label className="mb-1.5 block text-xs font-medium">名稱</label>
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="例：Stanley 產品端 / 行銷端"
+                required
+                disabled={creating}
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                用來識別這把金鑰是給誰用，方便日後管理
+              </p>
+            </div>
+
+            <div>
+              <label className="mb-1.5 block text-xs font-medium">過期時間</label>
+              <Select
+                value={expiry}
+                onChange={(e) => setExpiry(e.target.value)}
+                options={EXPIRY_OPTIONS}
+                disabled={creating}
+              />
+            </div>
+          </div>
+
+          <DialogFooter className="mt-6">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={creating}
+            >
+              取消
+            </Button>
+            <Button type="submit" disabled={creating || !name.trim()}>
+              {creating ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  建立中…
+                </>
+              ) : (
+                '建立'
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ───────────────────────────────────────────────────────────
+
+function CreatedApiKeyDialog({
+  keyData,
+  onOpenChange,
+}: {
+  keyData: CreatedApiKey | null;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    if (!keyData) return;
+    try {
+      await navigator.clipboard.writeText(keyData.key);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // fallback
+      alert(keyData.key);
+    }
+  };
+
+  return (
+    <Dialog open={!!keyData} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>金鑰已建立</DialogTitle>
+        </DialogHeader>
+
+        {keyData && (
+          <div className="mt-2 space-y-4">
+            <div className="rounded-md border-2 border-amber-300 bg-amber-50 p-3 text-xs text-amber-900">
+              ⚠️ <strong>請立刻複製並妥善保存</strong>。關閉視窗後將無法再次查看完整金鑰，列表只會顯示遮罩末 4 碼。
+            </div>
+
+            <div>
+              <label className="mb-1.5 block text-xs font-medium">{keyData.name}</label>
+              <div className="flex gap-2">
+                <code className="flex-1 overflow-x-auto rounded-md border bg-muted px-3 py-2.5 font-mono text-xs">
+                  {keyData.key}
+                </code>
+                <Button onClick={handleCopy} variant="outline" size="default">
+                  {copied ? (
+                    <>
+                      <Check className="mr-1.5 h-4 w-4 text-green-600" />
+                      已複製
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="mr-1.5 h-4 w-4" />
+                      複製
+                    </>
+                  )}
+                </Button>
+              </div>
+            </div>
+
+            <div className="rounded-md bg-muted/30 p-3 text-xs text-muted-foreground">
+              <p className="font-medium text-foreground">使用方式</p>
+              <pre className="mt-2 overflow-x-auto whitespace-pre-wrap font-mono text-[11px]">
+{`curl -X POST https://uat.open333crm.create360.ai/api/v1/knowledge/partner-ingest \\
+  -H "Authorization: Bearer ${keyData.key}" \\
+  -F "DocID=1234" \\
+  -F "Ver=1" \\
+  ...`}
+              </pre>
+            </div>
+          </div>
+        )}
+
+        <DialogFooter className="mt-6">
+          <Button onClick={() => onOpenChange(false)}>我已保存，關閉</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/database/prisma/migrations/20260507032522_partner_api_keys/migration.sql
+++ b/packages/database/prisma/migrations/20260507032522_partner_api_keys/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "partner_api_keys" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "tenantId" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "keyHash" TEXT NOT NULL,
+    "keyPrefix" VARCHAR(8) NOT NULL,
+    "keySuffix" VARCHAR(4) NOT NULL,
+    "expiresAt" TIMESTAMP(3),
+    "lastUsedAt" TIMESTAMP(3),
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdById" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "partner_api_keys_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "partner_api_keys_tenantId_isActive_idx" ON "partner_api_keys"("tenantId", "isActive");
+
+-- CreateIndex
+CREATE INDEX "partner_api_keys_keyPrefix_idx" ON "partner_api_keys"("keyPrefix");
+
+-- AddForeignKey
+ALTER TABLE "partner_api_keys" ADD CONSTRAINT "partner_api_keys_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "tenants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -208,6 +208,7 @@ model Tenant {
   portalSubmissions       PortalSubmission[]
   pointTransactions       PointTransaction[]
   shortLinks              ShortLink[]
+  partnerApiKeys          PartnerApiKey[]
 
   @@map("tenants")
 }
@@ -1400,4 +1401,28 @@ model MergeSuggestion {
 
   @@index([tenantId, status])
   @@map("merge_suggestions")
+}
+// ─────────────────────────────────────────────
+// Partner API Keys
+// ─────────────────────────────────────────────
+
+model PartnerApiKey {
+  id          String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId    String    @db.Uuid
+  name        String
+  keyHash     String
+  keyPrefix   String    @db.VarChar(8)
+  keySuffix   String    @db.VarChar(4)
+  expiresAt   DateTime?
+  lastUsedAt  DateTime?
+  isActive    Boolean   @default(true)
+  createdById String    @db.Uuid
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  tenant Tenant @relation(fields: [tenantId], references: [id])
+
+  @@index([tenantId, isActive])
+  @@index([keyPrefix])
+  @@map("partner_api_keys")
 }


### PR DESCRIPTION
## Summary

合作方（產品 / 行銷 / 客服）長期串接用的 API key，避免每 15 分鐘要 refresh agent JWT。固定只能呼叫 \`POST /knowledge/partner-ingest\`，與其他 endpoint 隔離。

## What changed

### DB
- **新 model `PartnerApiKey`**：tenantId / name / keyHash / keyPrefix(8 char) / keySuffix(4 char) / expiresAt? / lastUsedAt? / isActive / createdById
- 含正規 prisma migration

### Backend
- **`partner-api-key.service.ts`**：
  - \`createPartnerApiKey()\` — bcrypt hash 存 DB；raw key（\`pk_<64-hex>\`）只在建立時返回一次
  - \`verifyPartnerApiKey()\` — 用 keyPrefix 索引縮窄候選 → bcrypt verify → 檢查 expiresAt → fire-and-forget 更新 lastUsedAt
  - \`listPartnerApiKeys()\` / \`revokePartnerApiKey()\`
- **Auth plugin**：新 decorator \`authenticateJwtOrPartnerKey\`，\`pk_\` 開頭的 token 走 key 驗證、否則走 JWT。Key 驗證成功會建 synthetic agent（role=SUPERVISOR, isPartnerKey=true, apiKeyId）讓既有 \`requireSupervisor()\` guard 直接通過
- **knowledge.routes** preHandler 改條件式：\`partner-ingest\` 用雙路驗證，其他 routes 維持 JWT only
- **3 個 settings endpoint**：
  - \`GET /api/v1/settings/api-keys\`（masked 列表）
  - \`POST /api/v1/settings/api-keys\`（建立，返回 raw key 一次）
  - \`DELETE /api/v1/settings/api-keys/:id\`（撤銷，soft delete）

### Frontend
- 設定頁加「**API 金鑰**」tab
- 列表：名稱 / 遮罩末 4 碼（\`pk_a1b2c…f9e0\`）/ 啟用狀態 / 最後使用 / 過期時間 / 撤銷按鈕
- **建立 dialog**：名稱 + 過期下拉（永不過期 / 30 / 90 / 180 / 365 天）
- **建立成功 dialog**：一次性顯示 raw key + 複製按鈕 + curl 範例（含金鑰），警示「關閉後再也看不到」

## Security model

| 項目 | 設計 |
|---|---|
| Key 儲存 | bcryptjs (10 rounds)，與 agent password 同套件 |
| Key 顯示 | 明文僅在建立 dialog 顯示一次；列表只看 prefix + 末 4 碼 |
| Scope | 固定只能打 partner-ingest（其他 endpoint 一律 401） |
| 撤銷 | \`isActive=false\`（保留稽核），下次 verify 會拒絕 |
| 過期 | 可選永不過期或自訂天數；過期後 verify 拒絕 |
| 數量 | 不限 |
| 稽核 | \`lastUsedAt\` 每次成功 verify 自動更新 |

## Test plan

- [x] \`pnpm build\` 12/12 全綠
- [x] \`tsc --noEmit\` api+web 0 errors
- [ ] 部署後：
  - 設定 → API 金鑰 → 建立一把 → 出現 raw key dialog
  - 用該 key 打 partner-ingest curl → \`status: created\`
  - 撤銷該 key → 再次 curl → 401
  - 用過期 key → 401

## Note on previous workaround

UAT 之前用 admin agent JWT 給合作方，這次合併後可以建專用 key 取代。建議：
1. 在 UAT 設定頁建一把 \`Stanley\` 命名的 key
2. 把 raw key 給 Stanley 取代之前的 JWT
3. 文件 \`docs/partner-ingest-api.md\` 可以更新「Auth」段落為「使用永久 API key」

🤖 Generated with [Claude Code](https://claude.com/claude-code)