### PR TITLE
fix(prompt): 移除預設 system prompt 中的 Open333 品牌字樣

### DIFF
--- a/apps/api/src/modules/ai/llm.service.ts
+++ b/apps/api/src/modules/ai/llm.service.ts
@@ -14,15 +14,16 @@ import { getChatSettings } from '../settings/chat-settings.service.js';
 export type { HistoryMessage } from './providers/index.js';
 
 /**
- * Default CRM customer-service system prompt. Used when a tenant has not
- * customized its chatSystemPrompt yet (empty string).
+ * Default chat reply system prompt — brand-neutral. Tenants are expected to
+ * override this via Settings → Chat & Prompt for their own brand voice. This
+ * fallback is only used when chatSystemPrompt is empty.
  */
 export const CRM_REPLY_SYSTEM_PROMPT =
-  '你是「Open333」品牌的專業客服助手，負責回答客戶關於家電產品（冰箱、洗衣機、冷氣、電視等）的問題。\n' +
+  '你是一位專業的文字客服。請參考前面的對話脈絡與知識庫內容，用繁體中文回覆客戶問題。\n' +
   '請遵守以下規則：\n' +
-  '1. 全程使用繁體中文回覆，語氣親切專業\n' +
+  '1. 全程使用繁體中文回覆，語氣親切、專業、有耐心\n' +
   '2. 回覆控制在 3-5 句話內，簡潔扼要\n' +
-  '3. 如果知識庫有相關內容，優先引用知識庫的資訊\n' +
+  '3. 如果知識庫有相關內容，優先引用知識庫資訊回答\n' +
   '4. 如果無法確定答案，請說「我幫您確認一下，稍後由專人為您服務」\n' +
   '5. 不要編造保固期限、價格、技術規格等具體數字\n' +
   '6. 遇到客訴或緊急問題，建議客戶「我立刻為您轉接專人處理」\n' +
@@ -41,12 +42,12 @@ export const SUMMARIZE_SYSTEM_PROMPT =
  * The bot should ask a single clarifying question instead of guessing.
  */
 export const CLARIFY_SYSTEM_PROMPT =
-  '你是「Open333」品牌的客服助手。客戶剛剛的訊息資訊不足，無法判斷他真正的問題。' +
+  '你是一位專業的文字客服。客戶剛剛的訊息資訊不足，無法判斷他真正的問題。' +
   '請參考前面的對話脈絡，用繁體中文禮貌地反問**一個**最關鍵的澄清問題以取得更多資訊。\n' +
   '規則：\n' +
   '1. 只問一個問題，不要連珠炮\n' +
   '2. 問題要具體、可回答（避免「請問需要什麼幫助」這類空泛問句）\n' +
-  '3. 如果是家電問題，優先問：是哪個產品 / 故障狀況 / 型號\n' +
+  '3. 如果是產品問題，優先問：是哪個產品 / 故障狀況 / 型號\n' +
   '4. 整體控制在 2 句話以內\n' +
   '5. 不要編造或假設客戶的需求';
 


### PR DESCRIPTION
## Symptom

UAT 觀察到 Bot 對大同客戶的對話回覆：

> 「AK-47 並非 Open333 品牌的家電產品型號...」

但 client 是大同的客服，**完全沒設定要用 Open333 品牌**。

## Root cause

\`apps/api/src/modules/ai/llm.service.ts\` 三個 default system prompt 寫死了 \`「Open333」品牌\` 字樣：

\`\`\`ts
export const CRM_REPLY_SYSTEM_PROMPT =
  '你是「Open333」品牌的專業客服助手，負責回答客戶關於家電產品...';

export const CLARIFY_SYSTEM_PROMPT =
  '你是「Open333」品牌的客服助手...';
\`\`\`

當租戶的 \`chatSystemPrompt\` / \`clarifySystemPrompt\` 留空時，系統會 fallback 到這個 default，於是 Bot 自稱 Open333。

## Fix

把 default prompt 改成品牌中性：

- \`CRM_REPLY_SYSTEM_PROMPT\` → 「一位專業的文字客服」
- \`CLARIFY_SYSTEM_PROMPT\`   → 同上；「家電」改「產品」（更通用）
- \`SUMMARIZE_SYSTEM_PROMPT\` → 原本就無品牌字樣，不動

租戶仍可從 Settings → Chat & Prompt 自訂自己品牌的 prompt。

## Test plan

- [x] tsc --noEmit api → 0 errors
- [ ] 部署後對 Stanley 那條對話用 LINE 重新傳訊
- [ ] 預期 Bot 不再自稱 Open333；回覆會用「我們」之類的中性稱呼，或要求客戶提供更多資訊

## 後續：建議大同客戶端進 UI 客製

UAT 後台「知識庫 → Chat & Prompt」textarea 可填入大同專屬 prompt（例：「你是大同 (TATUNG) 的專業文字客服...」），完全覆蓋 default。

🤖 Generated with [Claude Code](https://claude.com/claude-code)