### PR TITLE
feat(partner-ingest): cmd=CREATE/UPDATE/DELETE + 軟刪語意

### DIFF
--- a/apps/api/src/modules/knowledge/knowledge.routes.ts
+++ b/apps/api/src/modules/knowledge/knowledge.routes.ts
@@ -18,10 +18,11 @@ import {
 import { parseFileToMarkdown } from './file-parser.service.js';
 import {
   ingestPartnerDoc,
+  parseCmd,
   type PartnerAttachmentInput,
 } from './partner-ingest.service.js';
 import { requireSupervisor } from '../../guards/rbac.guard.js';
-import { success, paginated } from '../../shared/utils/response.js';
+import { AppError, success, paginated } from '../../shared/utils/response.js';
 
 const createArticleSchema = z.object({
   title: z.string().min(1).max(200),
@@ -147,8 +148,9 @@ export default async function knowledgeRoutes(fastify: FastifyInstance) {
   });
 
   // POST /api/v1/knowledge/partner-ingest — 合作方單筆推送 (multipart/form-data)
-  // Fields: DocID, Ver, VerCreatTime, AI_Q, AI_A, Source/Soruce, Spec, IsAttached
-  // Files:  Attached (可多檔)
+  // Fields: cmd (CREATE/UPDATE/DELETE), DocID, Ver, VerCreatTime,
+  //         AI_Q, AI_A, Source/Soruce, Spec, IsAttached
+  // Files:  Attached (可多檔；DELETE 時忽略)
   fastify.post(
     '/partner-ingest',
     { preHandler: [requireSupervisor()] },
@@ -174,23 +176,23 @@ export default async function knowledgeRoutes(fastify: FastifyInstance) {
         }
       }
 
-      const docId = fields.DocID ?? '';
-      if (!docId) {
-        return reply.status(400).send({
-          success: false,
-          error: { code: 'BAD_REQUEST', message: 'DocID is required' },
-        });
-      }
-
-      // Tolerate Stanley's typo: accept both Source and Soruce
-      const source = fields.Source ?? fields.Soruce ?? '';
-
       try {
+        const cmd = parseCmd(fields.cmd);
+
+        const docId = fields.DocID ?? '';
+        if (!docId) {
+          throw new AppError('DocID is required', 'BAD_REQUEST', 400);
+        }
+
+        // Tolerate Stanley's typo: accept both Source and Soruce
+        const source = fields.Source ?? fields.Soruce ?? '';
+
         const result = await ingestPartnerDoc(
           fastify.prisma,
           request.agent.tenantId,
           request.agent.id,
           {
+            cmd,
             docId,
             ver: Number(fields.Ver) || 0,
             verCreatTime: fields.VerCreatTime ?? '',
@@ -199,11 +201,18 @@ export default async function knowledgeRoutes(fastify: FastifyInstance) {
             source,
             spec: fields.Spec,
             isAttached: fields.IsAttached === 'true',
-            attachments,
+            attachments: cmd === 'DELETE' ? [] : attachments,
           },
         );
         return reply.send(success(result));
       } catch (err) {
+        if (err instanceof AppError) {
+          return reply.status(err.statusCode).send({
+            success: false,
+            error: { code: err.code, message: err.message },
+          });
+        }
+        request.log.error({ err }, '[PartnerIngest] unexpected failure');
         return reply.status(500).send({
           success: false,
           error: {

--- a/apps/api/src/modules/knowledge/partner-ingest.service.ts
+++ b/apps/api/src/modules/knowledge/partner-ingest.service.ts
@@ -4,16 +4,18 @@
  * Receives one document at a time from a partner system (e.g. Stanley's
  * "Chatbot" feeder) via HTTP multipart and upserts it into KmArticle.
  *
- * Versioning is governed by `Ver`:
- *   - new DocID         → create
- *   - existing, newer   → update + replace attachments + re-embed
- *   - existing, same/old → skip (idempotent retries)
+ * 動作由 `cmd` 決定（CREATE / UPDATE / DELETE）。`Ver` 仍會檢查以防止亂序
+ * 重送把新版蓋成舊版：CREATE/UPDATE 收到 `Ver` ≤ 既有版本一律回 skipped。
+ * DELETE 採軟刪：status → ARCHIVED，附件保留但檢索端會排除。
  */
 
 import type { PrismaClient, Prisma } from '@prisma/client';
 import { uploadFile } from '../storage/storage.service.js';
 import { embedArticle } from '../embedding/embedding.service.js';
 import { logger } from '@open333crm/core';
+import { AppError } from '../../shared/utils/response.js';
+
+export type PartnerCmd = 'CREATE' | 'UPDATE' | 'DELETE';
 
 export interface PartnerAttachmentInput {
   buffer: Buffer;
@@ -22,6 +24,7 @@ export interface PartnerAttachmentInput {
 }
 
 export interface PartnerDocInput {
+  cmd: PartnerCmd;
   docId: string;
   ver: number;
   verCreatTime: string;
@@ -33,13 +36,32 @@ export interface PartnerDocInput {
   attachments: PartnerAttachmentInput[];
 }
 
+export type PartnerIngestStatus =
+  | 'created'
+  | 'updated'
+  | 'deleted'
+  | 'revived'
+  | 'skipped';
+
 export interface PartnerIngestResult {
-  status: 'created' | 'updated' | 'skipped';
+  status: PartnerIngestStatus;
   reason?: string;
   articleId: string;
   externalDocId: string;
   externalVer: number;
   attachmentsLinked: number;
+}
+
+export function parseCmd(raw: string | undefined): PartnerCmd {
+  const value = (raw ?? '').trim().toUpperCase();
+  if (value === 'CREATE' || value === 'UPDATE' || value === 'DELETE') {
+    return value;
+  }
+  throw new AppError(
+    `cmd must be CREATE, UPDATE or DELETE (got "${raw ?? ''}")`,
+    'INVALID_CMD',
+    400,
+  );
 }
 
 const MS_DATE_RE = /\/Date\((\d+)\)\//;
@@ -74,19 +96,37 @@ export async function ingestPartnerDoc(
   input: PartnerDocInput,
 ): Promise<PartnerIngestResult> {
   if (!input.docId) {
-    throw new Error('DocID is required');
+    throw new AppError('DocID is required', 'BAD_REQUEST', 400);
   }
 
-  const { spec, specRaw } = parseSpec(input.spec);
-  const importedAt = parseVerCreatTime(input.verCreatTime);
-
-  // 1. Look up existing article by (tenantId, externalDocId)
   const existing = await prisma.kmArticle.findUnique({
     where: { tenantId_externalDocId: { tenantId, externalDocId: input.docId } },
-    select: { id: true, externalVer: true },
+    select: { id: true, externalVer: true, status: true },
   });
 
-  // 2. Skip if not newer
+  if (input.cmd === 'DELETE') {
+    return handleDelete(prisma, input, existing);
+  }
+
+  // CREATE 要求 DocID 不存在或處於 ARCHIVED（復活）；既有且 PUBLISHED 視為衝突。
+  if (input.cmd === 'CREATE' && existing && existing.status !== 'ARCHIVED') {
+    throw new AppError(
+      `DocID "${input.docId}" already exists (use cmd=UPDATE instead)`,
+      'DOCID_CONFLICT',
+      409,
+    );
+  }
+
+  // UPDATE 必須要有既有的 article（含 ARCHIVED — 視為已刪除，請改送 CREATE 復活）。
+  if (input.cmd === 'UPDATE' && (!existing || existing.status === 'ARCHIVED')) {
+    throw new AppError(
+      `DocID "${input.docId}" not found (use cmd=CREATE instead)`,
+      'DOCID_NOT_FOUND',
+      404,
+    );
+  }
+
+  // 版本保護：CREATE/UPDATE 都要求 Ver 嚴格大於既有版本，避免亂序重送。
   if (existing && input.ver <= existing.externalVer) {
     return {
       status: 'skipped',
@@ -98,7 +138,68 @@ export async function ingestPartnerDoc(
     };
   }
 
-  // 3. Build common data payload
+  return writeArticle(prisma, tenantId, agentId, input, existing);
+}
+
+async function handleDelete(
+  prisma: PrismaClient,
+  input: PartnerDocInput,
+  existing: { id: string; externalVer: number; status: string } | null,
+): Promise<PartnerIngestResult> {
+  // 不存在 → idempotent，當作已刪除
+  if (!existing) {
+    logger.info(`[PartnerIngest] DELETE noop (not found) DocID=${input.docId}`);
+    return {
+      status: 'deleted',
+      reason: 'not found (idempotent)',
+      articleId: '',
+      externalDocId: input.docId,
+      externalVer: input.ver,
+      attachmentsLinked: 0,
+    };
+  }
+
+  // 已 ARCHIVED → 也視為 idempotent，不重複動作
+  if (existing.status === 'ARCHIVED') {
+    return {
+      status: 'deleted',
+      reason: 'already archived (idempotent)',
+      articleId: existing.id,
+      externalDocId: input.docId,
+      externalVer: existing.externalVer,
+      attachmentsLinked: 0,
+    };
+  }
+
+  // 軟刪：標記為 ARCHIVED + 清空向量（避免被檢索吐回）
+  await prisma.kmArticle.update({
+    where: { id: existing.id },
+    data: { status: 'ARCHIVED' },
+  });
+  await prisma.$executeRawUnsafe(
+    `UPDATE km_articles SET embedding = NULL WHERE id = $1::uuid`,
+    existing.id,
+  );
+
+  logger.info(`[PartnerIngest] DELETE (soft) DocID=${input.docId} articleId=${existing.id}`);
+  return {
+    status: 'deleted',
+    articleId: existing.id,
+    externalDocId: input.docId,
+    externalVer: existing.externalVer,
+    attachmentsLinked: 0,
+  };
+}
+
+async function writeArticle(
+  prisma: PrismaClient,
+  tenantId: string,
+  agentId: string,
+  input: PartnerDocInput,
+  existing: { id: string; externalVer: number; status: string } | null,
+): Promise<PartnerIngestResult> {
+  const { spec, specRaw } = parseSpec(input.spec);
+  const importedAt = parseVerCreatTime(input.verCreatTime);
   const summary = deriveSummary(input.aiA);
   const metadataExtras: Record<string, unknown> = {};
   if (specRaw) metadataExtras.specRaw = specRaw;
@@ -121,19 +222,18 @@ export async function ingestPartnerDoc(
   };
 
   let articleId: string;
-  let status: 'created' | 'updated';
+  let status: PartnerIngestStatus;
 
   if (existing) {
-    // 4a. Update existing + delete old attachments (cascade replacement)
+    // 既有 → 整批覆蓋附件 + 更新內容；若先前是 ARCHIVED 視為復活
     await prisma.kmArticleAttachment.deleteMany({ where: { articleId: existing.id } });
     await prisma.kmArticle.update({
       where: { id: existing.id },
       data: dataCommon,
     });
     articleId = existing.id;
-    status = 'updated';
+    status = existing.status === 'ARCHIVED' ? 'revived' : 'updated';
   } else {
-    // 4b. Create new
     const created = await prisma.kmArticle.create({
       data: {
         tenantId,
@@ -146,7 +246,6 @@ export async function ingestPartnerDoc(
     status = 'created';
   }
 
-  // 5. Upload attachments + create attachment rows
   let attachmentsLinked = 0;
   if (input.isAttached && input.attachments.length > 0) {
     for (const att of input.attachments) {
@@ -178,7 +277,6 @@ export async function ingestPartnerDoc(
     }
   }
 
-  // 6. Fire-and-forget re-embedding (so KB search reflects the latest content)
   embedArticle(prisma, articleId).catch((err) => {
     logger.error(
       `[PartnerIngest] Embedding failed for article ${articleId} (DocID ${input.docId}): ${(err as Error).message}`,


### PR DESCRIPTION
## Summary
- 合作方單筆推送 API 改由 `cmd` 欄位（CREATE/UPDATE/DELETE）明確指定動作，取代「靠 Ver 隱式判斷新舊」的舊行為
- DELETE 採**軟刪**：標記 `status=ARCHIVED` 並清空向量；檢索端本來就 `WHERE status='PUBLISHED'`，自然排除
- 錯誤路徑改走 `AppError`，回 4xx 而非全部 500，方便對方系統對帳

## 行為矩陣

| cmd | DocID 狀態 | 行為 | HTTP |
|---|---|---|---|
| CREATE | 不存在 | 建立 | 200 `status=created` |
| CREATE | 已存在 PUBLISHED | 衝突 | 409 `DOCID_CONFLICT` |
| CREATE | 已存在 ARCHIVED | 復活（覆蓋內容 + 附件 + status=PUBLISHED） | 200 `status=revived` |
| UPDATE | 存在 PUBLISHED 且 Ver 較新 | 整批覆蓋內容與附件、重算向量 | 200 `status=updated` |
| UPDATE | 不存在 / ARCHIVED | 拒絕 | 404 `DOCID_NOT_FOUND` |
| UPDATE | Ver ≤ 既有 | 略過，防止亂序重送 | 200 `status=skipped` |
| DELETE | 存在 | 軟刪 + 清向量 | 200 `status=deleted` |
| DELETE | 不存在 / 已 ARCHIVED | idempotent | 200 `status=deleted` |
| 任何 | `cmd` 缺值 / 非三者 | 拒絕 | 400 `INVALID_CMD` |

## 注意

- 附件採整批替換語意：UPDATE 時 Stanley 那邊**必須把所有附件重送**，後端會先 delete 再 create
- 軟刪不動 `KmArticleAttachment`，附件實體保留供未來稽核；若之後要排程清理 30 天前的 ARCHIVED 可再加 worker
- 沒有 schema 變更，不需 migration

## Test plan
- [ ] curl `cmd=CREATE` 新 DocID → 200 `status=created`
- [ ] curl `cmd=CREATE` 同 DocID → 409 `DOCID_CONFLICT`
- [ ] curl `cmd=UPDATE` 帶較大 Ver → 200 `status=updated`，附件被整批替換
- [ ] curl `cmd=UPDATE` 帶相同 Ver → 200 `status=skipped`
- [ ] curl `cmd=UPDATE` 帶不存在 DocID → 404
- [ ] curl `cmd=DELETE` 既有 DocID → 200 `status=deleted`，semanticSearch 不再吐回
- [ ] curl `cmd=DELETE` 同 DocID 第二次 → 200 idempotent
- [ ] curl `cmd=CREATE` 已 ARCHIVED 的 DocID → 200 `status=revived`，重新可被檢索
- [ ] curl 缺 `cmd` 欄位 → 400 `INVALID_CMD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)