### PR TITLE
docs(openspec): partner-ingest cmd 規格提案（CREATE/UPDATE/DELETE）

### DIFF
--- a/openspec/changes/2026-05-13-partner-ingest-cmd/design.md
+++ b/openspec/changes/2026-05-13-partner-ingest-cmd/design.md
@@ -1,0 +1,134 @@
+## Context
+
+Partner ingest 是合作方（目前是 Stanley 的 Chatbot 系統）唯一寫入 KB 的 API。從 PR #102（2026-05-06）上線後，動作行為一直是「比較 `Ver`」：
+
+- DocID 不存在 → create
+- DocID 存在且 `Ver` 較新 → update（含附件整批替換 + 重算 embedding）
+- DocID 存在且 `Ver` 相同或較舊 → skip（idempotent retry 友善）
+
+這個設計**沒有刪除路徑**。當合作方想要把一筆知識點下架，目前只能：
+1. 透過 KM 後台手動 archive（合作方無權限）
+2. 把 AI_A 改成空字串再推 update（hack，且 embedding 還是會跑）
+
+Stanley 在對接時明確要求**加 `cmd` 欄位顯式指定動作**，並要求 DELETE 行為。雙方約定**硬切**（同時上線新規格，不做向後相容）。
+
+## Goals / Non-Goals
+
+**Goals**
+
+- `cmd` 為必填，CREATE / UPDATE / DELETE 三個明確的動作
+- DELETE 採**軟刪**——保留 KmArticle 記錄、附件、`externalDocId`、`externalVer`，只把 `status` 轉 `ARCHIVED` 並清空 `embedding`
+- 復活機制：對 ARCHIVED 的 DocID 送 CREATE，視為復活（重新 PUBLISHED + 覆蓋內容）
+- 錯誤回應使用 4xx + 結構化錯誤碼，方便合作方對帳
+- 既有的 `Ver` 嚴格遞增保護**保留**，防止亂序重送
+- 既有的附件「整批替換」語意**保留**
+
+**Non-Goals**
+
+- 把 partner-ingest 搬到 worker（HTTP 改非同步會破壞對方對接）
+- ARCHIVED 文章的清理 worker（30 天後實體刪除）—— 留給未來
+- 對 KmArticle 手動管理流程的改動
+
+## Decisions
+
+### 為什麼用軟刪而不是硬刪
+
+**軟刪（採用）**：`status = ARCHIVED` + 清空 `embedding`。
+
+- ✅ 萬一合作方誤刪可以救（後台手動恢復 status 即可）
+- ✅ 附件保留供稽核
+- ✅ `externalDocId` 還在，未來若要復活（CREATE）可以直接覆蓋
+- ✅ RAG 檢索 (`embedding.service.ts:117`) 本來就 `WHERE status='PUBLISHED'`，ARCHIVED 自動排除，**不需改 SQL**
+- ⚠️ 附件還佔 S3 空間（後續可加清理 worker）
+
+**硬刪（拒絕）**：直接 `DELETE FROM km_articles`。
+
+- 風險太高，誤刪無法救
+- 對方若送錯 DocID 我們無從還原
+
+**主要考量**：合作方仍在對接初期，誤操作機率高，軟刪是保險做法。
+
+### 為什麼 ARCHIVED 也算「不存在」
+
+對 UPDATE 而言，**ARCHIVED ≡ 不存在**：
+
+- UPDATE 一個 ARCHIVED 的 DocID → 404 `DOCID_NOT_FOUND`
+- 合作方應該改送 CREATE（會觸發復活流程）
+
+**理由**：若允許 UPDATE 對 ARCHIVED 文章直接生效，合作方無法察覺「這筆已被刪過」。回 404 強迫對方主動選擇是要復活還是放棄。
+
+### CREATE 對 ARCHIVED 視為「復活」
+
+- CREATE + PUBLISHED 存在 → 409 `DOCID_CONFLICT`（不可覆蓋活的文章）
+- CREATE + ARCHIVED 存在 → 200 `status="revived"`（覆蓋並還原 PUBLISHED）
+- CREATE + 不存在 → 200 `status="created"`
+
+**為什麼用 CREATE 而不是另開新 cmd（RESTORE）**：
+
+- 對合作方系統而言，「我要重新上架這個 DocID」最自然的語意就是 CREATE
+- 多加一個 cmd 會增加對方系統的分支邏輯，無實益
+- 後端可以由 `existing.status === 'ARCHIVED'` 自動判斷
+
+### Ver 嚴格遞增保護保留
+
+即使 cmd 顯式指定，`Ver` 比較**仍然執行**：
+
+- CREATE 對新 DocID：`Ver` 可以是任意正整數
+- CREATE 復活：要求 `Ver` 嚴格大於既有（避免拿舊版資料復活）
+- UPDATE：要求 `Ver` 嚴格大於既有
+- 不符合 → 200 `status="skipped"`，內容不變（**不回 4xx**，因為這是合理的 retry 情境）
+- DELETE：不檢查 `Ver`（刪除動作 idempotent）
+
+### 錯誤碼設計
+
+| HTTP | code | 場景 |
+|---|---|---|
+| 400 | `BAD_REQUEST` | DocID 缺值 |
+| 400 | `INVALID_CMD` | cmd 缺值或非三者之一 |
+| 404 | `DOCID_NOT_FOUND` | UPDATE 對不存在或 ARCHIVED DocID |
+| 409 | `DOCID_CONFLICT` | CREATE 對既有 PUBLISHED DocID |
+| 500 | `INGEST_FAILED` | 其他未預期錯誤 |
+
+回應結構統一：`{ success: false, error: { code, message } }`
+
+成功回應：`{ success: true, data: { status, articleId, externalDocId, externalVer, attachmentsLinked, reason? } }`，其中 `status` 可能值：`created` / `updated` / `revived` / `deleted` / `skipped`。
+
+### 為什麼不搬 worker
+
+partner-ingest 目前是 inline HTTP handler——收檔、寫 DB、上傳 S3 都同步。理論上附件大時應該搬 worker，但：
+
+1. **API 回應形狀**：對方要靠 `status` 對帳；改非同步要回 job id + 查狀態 endpoint，破壞現有對接
+2. **附件量級**：目前合作方推的多是 PDF / 圖片，單檔 < 5 MB，同步上傳可接受
+3. **embedding 已經 fire-and-forget**：真正慢的步驟（vector 重算）已經不阻塞 HTTP 回應
+4. **PR #115 搬 worker 的目標是定時 + 重型工作**（SLA poll、automation rule），跟「使用者觸發的 ingest」性質不同
+
+若未來 Stanley 真的開始推大檔（>10 MB）或頻率變高，再開新 proposal 把 partner-ingest 改成「接收→入 queue→回 job id」的非同步模式。
+
+## 行為矩陣（給合作方對照）
+
+| cmd | DocID 狀態 | Ver 比較 | 結果 | HTTP |
+|---|---|---|---|---|
+| CREATE | 不存在 | — | 建立 PUBLISHED | 200 `status=created` |
+| CREATE | PUBLISHED 存在 | — | 拒絕 | **409 DOCID_CONFLICT** |
+| CREATE | ARCHIVED 存在 | 新 Ver 較大 | 復活並覆蓋 | 200 `status=revived` |
+| CREATE | ARCHIVED 存在 | 新 Ver ≤ 既有 | 不動 | 200 `status=skipped` |
+| UPDATE | 不存在 | — | 拒絕 | **404 DOCID_NOT_FOUND** |
+| UPDATE | ARCHIVED 存在 | — | 拒絕（請改 CREATE） | **404 DOCID_NOT_FOUND** |
+| UPDATE | PUBLISHED 存在 | 新 Ver 較大 | 覆蓋內容 + 附件 + 重算 | 200 `status=updated` |
+| UPDATE | PUBLISHED 存在 | 新 Ver ≤ 既有 | 不動 | 200 `status=skipped` |
+| DELETE | 不存在 | — | idempotent | 200 `status=deleted` (`reason=not found`) |
+| DELETE | PUBLISHED 存在 | — | 軟刪 | 200 `status=deleted` |
+| DELETE | ARCHIVED 存在 | — | idempotent | 200 `status=deleted` (`reason=already archived`) |
+| 任何 | — | — | `cmd` 缺值/非法 | **400 INVALID_CMD** |
+
+## Risks / Trade-offs
+
+- **[Risk]** 合作方上線時序與後端不同步 → 一邊送舊格式（無 cmd）會立刻 400。**Mitigation**：規格上線前跟 Stanley 約定共同切換時間
+- **[Risk]** 軟刪累積導致 S3 空間膨脹 → 附件不清理，長期會佔位。**Mitigation**：未來加 30 天清理 worker（另開 proposal）
+- **[Risk]** 復活流程被誤觸 → 對方系統誤把 ARCHIVED 的 DocID 再 CREATE，會自動還原。**Mitigation**：回應裡 `status="revived"` 跟 `status="created"` 明確區分，對方系統可警示
+
+## Migration Plan
+
+- **無資料庫變動**
+- API 規格硬切：合作方在前、後端在後上線（前端送舊格式只會 400，不會壞資料）
+- Stanley 同步告知變更

--- a/openspec/changes/2026-05-13-partner-ingest-cmd/proposal.md
+++ b/openspec/changes/2026-05-13-partner-ingest-cmd/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+合作方（Stanley 的 Chatbot feeder）目前透過 `POST /api/v1/knowledge/partner-ingest` 推送知識點，動作（建立 / 更新 / 移除）是靠後端比較 `Ver` 的大小**隱式推導**——`Ver` 較大視為更新、相同/較小視為略過，**沒有刪除語意**。這造成兩個問題：
+
+1. **語意不明**：對方無法在 request 中明確表達「我要刪除這筆知識點」。目前若一個 DocID 不再使用，知識庫端就會一直留著舊資料、繼續被 RAG 檢索吐回。
+2. **錯誤回饋模糊**：當對方推送出錯（例如 DocID 拼錯、Ver 重複），後端只能回統一的 200 + `status=skipped`，對方系統難以對帳。
+
+Stanley 已正式要求加入 `cmd` 欄位（CREATE / UPDATE / DELETE）來明確指定動作。雙方約定**硬切**（不做向後相容 fallback），所以本次規格上線時對方系統會同步更新。
+
+## What Changes
+
+- `POST /api/v1/knowledge/partner-ingest` 新增**必填**欄位 `cmd`（值：CREATE / UPDATE / DELETE）
+- 行為矩陣（詳見 design.md）：
+  - **CREATE**：DocID 不存在 → 建立；DocID 已存在且 PUBLISHED → 409；DocID 已存在且 ARCHIVED → 復活（覆蓋內容 + 附件，status=PUBLISHED）
+  - **UPDATE**：DocID 存在 PUBLISHED 且 `Ver` 嚴格遞增 → 整批覆蓋內容 + 附件、重算 embedding；不存在或 ARCHIVED → 404；`Ver` ≤ 既有 → 200 `status=skipped`
+  - **DELETE**：軟刪——`status` 轉為 `ARCHIVED`、`embedding` 清空；附件保留（供未來稽核）；不存在或已 ARCHIVED → 200 idempotent
+- 新增 HTTP 錯誤碼：
+  - `400 INVALID_CMD`：`cmd` 缺值或非三者之一
+  - `404 DOCID_NOT_FOUND`：UPDATE 找不到 DocID
+  - `409 DOCID_CONFLICT`：CREATE 已存在 PUBLISHED DocID
+- 既有 `Ver` 嚴格遞增保護**保留**：CREATE/UPDATE 收到 `Ver` ≤ 既有 → `status=skipped`（防止亂序重送把新版蓋成舊版）
+- 既有附件「整批替換」語意**保留**：UPDATE / 復活時先刪舊附件再寫新的；DELETE 不動附件
+
+## Capabilities
+
+### Modified Capabilities
+
+- **`km-ingestion`**：合作方推送的動作由必填 `cmd` 欄位明確指定，取代「靠 `Ver` 隱式推導」的舊行為；新增軟刪（ARCHIVED）語意，且 ARCHIVED 文章自動排除於 RAG 檢索之外
+
+## Impact
+
+### 程式碼
+
+- `apps/api/src/modules/knowledge/partner-ingest.service.ts` — 主要邏輯，重寫 `ingestPartnerDoc()`，依 `cmd` 分流；新增 `parseCmd()`、`handleDelete()`、`writeArticle()`
+- `apps/api/src/modules/knowledge/knowledge.routes.ts` — 解析 multipart 多一個 `cmd` 欄位，錯誤改走 `AppError` 對應正確 HTTP code
+
+### Spec
+
+- `openspec/specs/km-ingestion/spec.md` — 追加 Partner Doc Mutation Command 段落（在 archive 階段合進主 spec）
+
+### 不需要
+
+- **無 schema 變動**：`KmStatus.ARCHIVED` 已存在於 `packages/database/prisma/schema.prisma`；KB retrieval（`apps/api/src/modules/embedding/embedding.service.ts:118`）原本就 `WHERE status='PUBLISHED'`，ARCHIVED 自動排除
+- **不搬 worker**：partner-ingest 同步寫 DB + S3 是繼承既有設計（HTTP 要回 status 給對方），本次只動行為語意；架構性的 worker 化另開 proposal
+- **不需 migration**
+
+## Non-Goals
+
+- 把 partner-ingest 改成走 BullMQ queue（API 回應從同步變非同步會破壞對方對接，需另外規劃）
+- ARCHIVED 文章的清理 worker（30 天後實體刪除）——附件先保留供稽核，未來再加
+- 任何對前端 KB 文章管理頁面的改動（手動建立的 KmArticle 不受影響）

--- a/openspec/changes/2026-05-13-partner-ingest-cmd/specs/km-ingestion/spec.md
+++ b/openspec/changes/2026-05-13-partner-ingest-cmd/specs/km-ingestion/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: Partner Doc Mutation Command
+
+The `POST /api/v1/knowledge/partner-ingest` endpoint SHALL accept a **required** `cmd` field with values `CREATE`, `UPDATE`, or `DELETE` (case-insensitive after trim) that explicitly specifies the intended mutation. Missing or invalid `cmd` MUST be rejected with HTTP 400 `INVALID_CMD`.
+
+#### Scenario: CREATE on new DocID
+- **GIVEN** no `KmArticle` exists with `(tenantId, externalDocId)`
+- **WHEN** the partner sends `cmd=CREATE` with required fields
+- **THEN** a new `KmArticle` is created with `status=PUBLISHED`
+- **AND** the response is HTTP 200 with `data.status="created"`
+
+#### Scenario: CREATE on existing PUBLISHED DocID
+- **GIVEN** a `KmArticle` exists with `status=PUBLISHED`
+- **WHEN** the partner sends `cmd=CREATE` for the same DocID
+- **THEN** the existing article is left untouched
+- **AND** the response is HTTP 409 with `error.code="DOCID_CONFLICT"`
+
+#### Scenario: CREATE on existing ARCHIVED DocID (revive)
+- **GIVEN** a `KmArticle` exists with `status=ARCHIVED` and `externalVer` equal to V0
+- **WHEN** the partner sends `cmd=CREATE` with `Ver` strictly greater than V0
+- **THEN** the article's `status` is set to `PUBLISHED`, content fields and attachments are replaced, embedding is recalculated
+- **AND** the response is HTTP 200 with `data.status="revived"`
+
+#### Scenario: UPDATE missing DocID
+- **GIVEN** no `KmArticle` exists, OR an existing one has `status=ARCHIVED`
+- **WHEN** the partner sends `cmd=UPDATE`
+- **THEN** the response is HTTP 404 with `error.code="DOCID_NOT_FOUND"`
+
+#### Scenario: UPDATE with newer Ver
+- **GIVEN** a `KmArticle` with `status=PUBLISHED` and `externalVer` equal to V0
+- **WHEN** the partner sends `cmd=UPDATE` with `Ver` strictly greater than V0
+- **THEN** content fields are overwritten, all attachments are deleted and the new attachments uploaded, embedding is recalculated
+- **AND** the response is HTTP 200 with `data.status="updated"`
+
+#### Scenario: UPDATE with stale Ver
+- **GIVEN** a `KmArticle` with `externalVer` equal to V0
+- **WHEN** the partner sends `cmd=UPDATE` (or `cmd=CREATE` for ARCHIVED) with `Ver` ≤ V0
+- **THEN** the article is left untouched
+- **AND** the response is HTTP 200 with `data.status="skipped"` and `data.reason` indicating stale Ver
+
+#### Scenario: DELETE soft-delete an existing PUBLISHED DocID
+- **GIVEN** a `KmArticle` with `status=PUBLISHED`
+- **WHEN** the partner sends `cmd=DELETE`
+- **THEN** the article's `status` is set to `ARCHIVED`, its `embedding` is set to NULL, attachments are **retained**
+- **AND** the response is HTTP 200 with `data.status="deleted"`
+
+#### Scenario: DELETE idempotency for missing or already-archived DocID
+- **GIVEN** no `KmArticle` exists, OR an existing one already has `status=ARCHIVED`
+- **WHEN** the partner sends `cmd=DELETE`
+- **THEN** no mutation occurs
+- **AND** the response is HTTP 200 with `data.status="deleted"` and `data.reason` indicating idempotent no-op
+
+#### Scenario: Invalid or missing cmd
+- **WHEN** the partner sends a request whose `cmd` field is missing, empty, or not one of `CREATE` / `UPDATE` / `DELETE` (case-insensitive)
+- **THEN** the response is HTTP 400 with `error.code="INVALID_CMD"`
+- **AND** no mutation occurs
+
+### Requirement: Archived Articles Excluded from Retrieval
+
+KM retrieval pathways — semantic search (`semanticSearch`) and bulk re-embed (`bulkReembed`) — SHALL filter on `status = 'PUBLISHED'`. Articles with `status = 'ARCHIVED'` MUST NOT appear in AI/search responses, even if their embeddings exist.
+
+#### Scenario: ARCHIVED article is not returned by semantic search
+- **GIVEN** a `KmArticle` with `status=ARCHIVED` whose content semantically matches the query
+- **WHEN** a user calls `POST /api/v1/knowledge/search`
+- **THEN** the article does not appear in the returned results
+
+#### Scenario: ARCHIVED article is skipped by bulk re-embed
+- **WHEN** `POST /api/v1/knowledge/bulk-embed` runs
+- **THEN** only articles with `status=PUBLISHED` are counted and re-embedded; ARCHIVED articles are skipped

--- a/openspec/changes/2026-05-13-partner-ingest-cmd/tasks.md
+++ b/openspec/changes/2026-05-13-partner-ingest-cmd/tasks.md
@@ -1,0 +1,56 @@
+## 1. Spec / 提案文件
+
+- [x] 1.1 寫 proposal.md（Why / What Changes / Capabilities / Impact / Non-Goals）
+- [x] 1.2 寫 design.md（行為矩陣、決策理由、Trade-offs）
+- [x] 1.3 寫 spec delta（specs/km-ingestion/spec.md）
+- [x] 1.4 寫 tasks.md（本檔）
+- [ ] 1.5 開 docs PR，等 Stanley + 內部 review 規格
+
+## 2. Service Layer 改動
+
+- [ ] 2.1 在 `apps/api/src/modules/knowledge/partner-ingest.service.ts` 加 `parseCmd(raw)`：value trim + 大寫化、驗證屬於 `CREATE`/`UPDATE`/`DELETE`，否則 throw `AppError('...', 'INVALID_CMD', 400)`
+- [ ] 2.2 在 `PartnerDocInput` 介面新增 `cmd: PartnerCmd` 必填欄位
+- [ ] 2.3 把 `PartnerIngestResult.status` 型別擴充為 `'created' | 'updated' | 'deleted' | 'revived' | 'skipped'`
+- [ ] 2.4 重寫 `ingestPartnerDoc()`：先 lookup existing (含 `status`)，依 `cmd` 分流到 `handleDelete()` / 衝突檢查 / `writeArticle()`
+- [ ] 2.5 新增 `handleDelete()`：existing 不存在或已 ARCHIVED → idempotent；PUBLISHED → `status=ARCHIVED` + `embedding=NULL` (`UPDATE km_articles SET embedding = NULL WHERE id = $1::uuid`)
+- [ ] 2.6 抽出 `writeArticle()`：原本 4a/4b 的 update/create 分支，含附件整批替換、fire-and-forget embedding；ARCHIVED → PUBLISHED 時 status 標 `revived`
+
+## 3. Route Handler 改動
+
+- [ ] 3.1 `apps/api/src/modules/knowledge/knowledge.routes.ts` import `parseCmd` + `AppError`
+- [ ] 3.2 在 `/partner-ingest` handler 內讀 `fields.cmd`、呼叫 `parseCmd(fields.cmd)`
+- [ ] 3.3 `cmd === 'DELETE'` 時將 `attachments` 傳成空陣列（不浪費頻寬寫 S3，使用者就算誤傳也忽略）
+- [ ] 3.4 catch 區段優先處理 `AppError`，回 `err.statusCode` + `{ code, message }`；其他 error 回 500 `INGEST_FAILED`
+- [ ] 3.5 更新 route 上方註解，列出新欄位 `cmd`
+
+## 4. 錯誤碼
+
+- [ ] 4.1 `INVALID_CMD` (400)：在 `parseCmd` 內 throw
+- [ ] 4.2 `BAD_REQUEST` (400)：DocID 缺值
+- [ ] 4.3 `DOCID_CONFLICT` (409)：CREATE 對已存在 PUBLISHED DocID
+- [ ] 4.4 `DOCID_NOT_FOUND` (404)：UPDATE 對不存在或 ARCHIVED DocID
+- [ ] 4.5 `INGEST_FAILED` (500)：未預期錯誤兜底
+
+## 5. Build / Type Check
+
+- [ ] 5.1 `pnpm --filter @open333crm/api build` 零 TS error
+- [ ] 5.2 確認 PR #115（automation/sla 搬 worker）的改動不影響 partner-ingest 的 import 路徑
+
+## 6. Manual QA（合 PR 前）
+
+- [ ] 6.1 `cmd=CREATE` 新 DocID → 200 `status=created`，KB 後台看得到 PUBLISHED 文章
+- [ ] 6.2 `cmd=CREATE` 已存在 PUBLISHED DocID → 409 `DOCID_CONFLICT`
+- [ ] 6.3 `cmd=UPDATE` 帶 Ver 較大 → 200 `status=updated`，附件被整批替換、向量重算
+- [ ] 6.4 `cmd=UPDATE` 帶相同/較小 Ver → 200 `status=skipped`
+- [ ] 6.5 `cmd=UPDATE` 對不存在 DocID → 404 `DOCID_NOT_FOUND`
+- [ ] 6.6 `cmd=DELETE` 既有 PUBLISHED DocID → 200 `status=deleted`，KB 後台變 ARCHIVED，`semanticSearch` 不再吐回
+- [ ] 6.7 `cmd=DELETE` 同 DocID 第二次 → 200 idempotent (`reason=already archived`)
+- [ ] 6.8 `cmd=DELETE` 完全不存在的 DocID → 200 idempotent (`reason=not found`)
+- [ ] 6.9 `cmd=CREATE` 對已 ARCHIVED 的 DocID + 較大 Ver → 200 `status=revived`，重新可被 RAG 檢索
+- [ ] 6.10 缺 `cmd` 欄位 → 400 `INVALID_CMD`
+
+## 7. Spec Sync（at archive）
+
+- [ ] 7.1 把 `specs/km-ingestion/spec.md`（本 change 內的 delta）合進主 spec `openspec/specs/km-ingestion/spec.md`
+- [ ] 7.2 CHANGELOG.md `[Unreleased]` `### Added` 補 partner-ingest cmd 條目
+- [ ] 7.3 通知 Stanley 規格已正式上線、可開始改他那端


### PR DESCRIPTION
> **規格提案**，不含程式碼。請先 review 規格，等內部 + Stanley 對齊後再開實作 PR。

## Summary

合作方（Stanley Chatbot feeder）目前透過 \`POST /api/v1/knowledge/partner-ingest\` 推送知識點，動作（建立/更新/移除）是靠後端比較 \`Ver\` 隱式推導，**沒有刪除路徑**。

本提案加入必填 \`cmd\` 欄位（CREATE/UPDATE/DELETE），讓動作語意明確、可對帳，並引入軟刪（ARCHIVED）。

## 行為摘要

| cmd | DocID 狀態 | 行為 | HTTP |
|---|---|---|---|
| CREATE | 不存在 | 建立 PUBLISHED | 200 \`status=created\` |
| CREATE | PUBLISHED 存在 | 拒絕 | **409 DOCID_CONFLICT** |
| CREATE | ARCHIVED 存在 + 新 Ver | 復活 | 200 \`status=revived\` |
| UPDATE | 存在 PUBLISHED + 新 Ver | 整批覆蓋 | 200 \`status=updated\` |
| UPDATE | 不存在 / ARCHIVED | 拒絕 | **404 DOCID_NOT_FOUND** |
| UPDATE | Ver ≤ 既有 | 略過 | 200 \`status=skipped\` |
| DELETE | 存在 | 軟刪（status→ARCHIVED + 清向量） | 200 \`status=deleted\` |
| DELETE | 不存在 / 已 ARCHIVED | idempotent | 200 \`status=deleted\` |
| 任何 | — | cmd 缺值/非法 | **400 INVALID_CMD** |

## 範圍外（Non-Goals）

- 把 partner-ingest 搬到 worker（HTTP 改非同步會破壞對方對接，另開 proposal）
- ARCHIVED 文章的清理 worker（30 天後實體刪除）
- 對 KmArticle 手動管理流程的改動

## 重點決策（見 design.md）

- **軟刪 vs 硬刪**：軟刪，誤刪可救、附件保留供稽核
- **ARCHIVED 對 UPDATE ≡ 不存在**：UPDATE 改送 CREATE 才能復活，避免合作方系統意外覆蓋已刪文章
- **Ver 嚴格遞增保護保留**：即使 cmd 顯式指定，仍防止亂序重送把新版蓋成舊版
- **不搬 worker 的理由**：API 回應形狀（status 對帳）、附件量級小、embedding 已 fire-and-forget

## 歷史說明

相同議題曾在 PR #114（2026-05-12）短暫合進 main，但隔日（2026-05-13）被 PR #115 的 force-push 覆蓋移除。規格還沒給 Stanley，這次走完整 OpenSpec 流程從頭來：先規格 → 再實作 → 跟對方同步上線。

## 檔案

- \`openspec/changes/2026-05-13-partner-ingest-cmd/proposal.md\`
- \`openspec/changes/2026-05-13-partner-ingest-cmd/design.md\`
- \`openspec/changes/2026-05-13-partner-ingest-cmd/specs/km-ingestion/spec.md\`
- \`openspec/changes/2026-05-13-partner-ingest-cmd/tasks.md\`

## Review checklist

- [ ] 內部：軟刪 vs 硬刪的取捨同意
- [ ] 內部：不搬 worker 的決定同意（或要求一起做）
- [ ] Stanley：cmd 欄位定義、錯誤碼、回應 status 值清楚
- [ ] Stanley：知道硬切（無向後相容），雙方同步上線時間

合 PR 後我開實作 PR \`feat/partner-ingest-cmd-v2\`，依 tasks.md 走。

🤖 Generated with [Claude Code](https://claude.com/claude-code)