### PR TITLE
fix(knowledge): partner-ingest 拒收非 UTF-8 fields + 列表加分頁

### DIFF
--- a/apps/api/src/modules/knowledge/knowledge.routes.ts
+++ b/apps/api/src/modules/knowledge/knowledge.routes.ts
@@ -177,6 +177,50 @@ export default async function knowledgeRoutes(fastify: FastifyInstance) {
         }
       }
 
+      // Reject non-UTF-8 input early. multipart text fields without an
+      // explicit charset are decoded as UTF-8 strict; if the sender pushed
+      // e.g. Big5 bytes, every multi-byte char collapses to U+FFFD before we
+      // ever see it. Writing that to DB is destructive (raw bytes are lost),
+      // so we 400 the request instead and surface enough info for the sender
+      // to fix their client.
+      const REPLACEMENT_CHAR = '�';
+      const badFields: { name: string; preview: string; hex: string }[] = [];
+      for (const [name, value] of Object.entries(fields)) {
+        if (value.includes(REPLACEMENT_CHAR)) {
+          badFields.push({
+            name,
+            preview: value.slice(0, 80),
+            hex: Buffer.from(value, 'utf8').subarray(0, 80).toString('hex'),
+          });
+        }
+      }
+      for (const att of attachments) {
+        if (att.filename.includes(REPLACEMENT_CHAR)) {
+          badFields.push({
+            name: `Attached.filename(${att.filename.slice(0, 40)})`,
+            preview: att.filename,
+            hex: Buffer.from(att.filename, 'utf8').toString('hex'),
+          });
+        }
+      }
+      if (badFields.length > 0) {
+        request.log.warn(
+          { docId: fields.DocID, cmd: fields.cmd, badFields },
+          '[PartnerIngest] rejected: non-UTF-8 fields detected',
+        );
+        return reply.status(400).send({
+          success: false,
+          error: {
+            code: 'NON_UTF8_FIELDS',
+            message:
+              'One or more multipart fields are not valid UTF-8. ' +
+              'Likely your HTTP client is sending Big5/GBK bytes; ' +
+              'convert text to UTF-8 (and set Content-Type charset=utf-8) before sending.',
+            details: { fields: badFields.map((f) => f.name) },
+          },
+        });
+      }
+
       try {
         const cmd = parseCmd(fields.cmd);
 

--- a/apps/web/src/app/dashboard/knowledge/page.tsx
+++ b/apps/web/src/app/dashboard/knowledge/page.tsx
@@ -10,6 +10,7 @@ import { EmbeddingSettings } from '@/components/knowledge/EmbeddingSettings';
 import { ChatPromptSettings } from '@/components/knowledge/ChatPromptSettings';
 import { Topbar } from '@/components/layout/Topbar';
 import { SearchInput } from '@/components/shared/SearchInput';
+import { Pagination } from '@/components/shared/Pagination';
 import { Button } from '@/components/ui/button';
 import { Select } from '@/components/ui/select';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
@@ -24,10 +25,13 @@ const statusTabs = [
   { value: 'ARCHIVED', label: '已封存' },
 ];
 
+const PAGE_SIZE = 50;
+
 export default function KnowledgePage() {
   const [statusFilter, setStatusFilter] = useState('all');
   const [categoryFilter, setCategoryFilter] = useState('');
   const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingArticle, setEditingArticle] = useState<any>(null);
   const [importOpen, setImportOpen] = useState(false);
@@ -39,11 +43,21 @@ export default function KnowledgePage() {
   const [searching, setSearching] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
 
-  const { articles, isLoading, mutate } = useKnowledge({
+  const { articles, meta, isLoading, mutate } = useKnowledge({
     status: statusFilter === 'all' ? undefined : statusFilter,
     category: categoryFilter || undefined,
     q: search || undefined,
+    page,
+    limit: PAGE_SIZE,
   });
+
+  const totalPages = meta?.totalPages ?? 1;
+  const total = meta?.total ?? articles.length;
+
+  // Reset to page 1 whenever filters change
+  React.useEffect(() => {
+    setPage(1);
+  }, [statusFilter, categoryFilter, search]);
 
   const { categories } = useCategories();
 
@@ -192,6 +206,18 @@ export default function KnowledgePage() {
                 onArchive={handleArchive}
                 onDelete={handleDelete}
               />
+              {totalPages > 1 && (
+                <div className="flex items-center justify-between gap-4 border-t px-4 py-3">
+                  <span className="text-sm text-muted-foreground">
+                    共 {total} 篇 · 第 {page} / {totalPages} 頁
+                  </span>
+                  <Pagination
+                    page={page}
+                    totalPages={totalPages}
+                    onPageChange={setPage}
+                  />
+                </div>
+              )}
             </div>
           </TabsContent>
 

--- a/apps/web/src/components/shared/Pagination.tsx
+++ b/apps/web/src/components/shared/Pagination.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import React from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface PaginationProps {
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  className?: string;
+}
+
+function buildPageRange(page: number, totalPages: number): (number | 'ellipsis')[] {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+  const pages: (number | 'ellipsis')[] = [1];
+  const start = Math.max(2, page - 1);
+  const end = Math.min(totalPages - 1, page + 1);
+  if (start > 2) pages.push('ellipsis');
+  for (let i = start; i <= end; i++) pages.push(i);
+  if (end < totalPages - 1) pages.push('ellipsis');
+  pages.push(totalPages);
+  return pages;
+}
+
+export function Pagination({ page, totalPages, onPageChange, className }: PaginationProps) {
+  if (totalPages <= 1) return null;
+
+  const pages = buildPageRange(page, totalPages);
+
+  return (
+    <div className={cn('flex items-center justify-center gap-1', className)}>
+      <button
+        type="button"
+        className="flex items-center gap-1 rounded-md border px-3 py-1.5 text-sm disabled:opacity-50"
+        disabled={page <= 1}
+        onClick={() => onPageChange(page - 1)}
+      >
+        <ChevronLeft className="h-4 w-4" />
+        上一頁
+      </button>
+
+      {pages.map((p, i) =>
+        p === 'ellipsis' ? (
+          <span key={`e${i}`} className="px-2 text-sm text-muted-foreground">
+            …
+          </span>
+        ) : (
+          <button
+            key={p}
+            type="button"
+            onClick={() => onPageChange(p)}
+            className={cn(
+              'min-w-9 rounded-md border px-2.5 py-1.5 text-sm',
+              p === page
+                ? 'border-primary bg-primary text-primary-foreground'
+                : 'hover:bg-accent',
+            )}
+          >
+            {p}
+          </button>
+        ),
+      )}
+
+      <button
+        type="button"
+        className="flex items-center gap-1 rounded-md border px-3 py-1.5 text-sm disabled:opacity-50"
+        disabled={page >= totalPages}
+        onClick={() => onPageChange(page + 1)}
+      >
+        下一頁
+        <ChevronRight className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- partner-ingest 收到非 UTF-8 multipart text fields 時直接回 400，避免再寫壞資料進 DB
- 知識庫列表頁加分頁（原本預設 limit=50 但 UI 沒有換頁，超過 50 筆只能看第一頁）
- 抽出共用 Pagination 元件，可給其他列表頁重用

## 背景

UAT 上 526 篇 KB 文章有 520 篇 title 變亂碼（），起初看像 DB 編碼問題，實測：
- DB cluster `server_encoding=UTF8 / en_US.utf8`，完全正常
- 撈 raw bytes 發現 hex pattern 是 `efbfbd <ASCII byte>` 反覆出現
- `efbfbd` 是 U+FFFD 取代字元的 UTF-8 編碼，緊跟的 ASCII byte 對應 Big5 雙位元組的低位 byte（例：「大」Big5=`a4 6a` → `<FFFD>j`、「同」Big5=`a6 50` → `<FFFD>P`）

判定：上游 partner-ingest client 在 5/13–5/15 之間從 UTF-8 改成送 Big5，fastify-multipart 預設 UTF-8 strict decode 把所有 high byte 換成 U+FFFD 寫進 DB，原始 bytes 永久遺失。

DB 內已壞的 520 筆無法從我們這邊還原，需上游重推。本 PR 的目標是**擋住新的壞資料 + 修後台 UI**，不處理歷史資料。

## Changes

### `apps/api/src/modules/knowledge/knowledge.routes.ts`
- partner-ingest handler 解完 multipart fields 後，逐欄掃 U+FFFD（含 attachment filename）
- 偵測到 → 回 `400 NON_UTF8_FIELDS`，error message 直接指引上游「請改 UTF-8 + 設 charset=utf-8」
- API log warn 等級記 docId / cmd / 壞欄位名稱 + hex 前 80 bytes，方便對方 debug

### `apps/web/src/app/dashboard/knowledge/page.tsx`
- 加 \`page\` state，傳給 \`useKnowledge\`
- 列表底下顯示「共 X 篇 · 第 N / M 頁」+ Pagination 元件
- 切換 status / category / search 時自動回第 1 頁

### `apps/web/src/components/shared/Pagination.tsx`（新檔）
- 上一頁 / 數字頁碼 / 下一頁
- ≤7 頁全顯示，>7 頁自動省略（`1 … N-1 N N+1 … total`）

## Test plan

- [ ] 後台知識庫列表能看到分頁元件、能切換頁碼
- [ ] 切換 tab / 分類 / 搜尋後分頁回到第 1 頁
- [ ] partner-ingest 收到 UTF-8 正常資料 → 寫入正常（regression）
- [ ] partner-ingest 收到 Big5 資料 → 回 400 + log 看得到 hex
- [ ] 部署後請 Stanley 重試一筆，預期會立刻拿到 400 並看到具體錯誤訊息

## 後續（不在本 PR）

- 等 Stanley 修好 client encoding 後，請他重推全部受影響 DocID（partner-ingest 是 idempotent，會自動覆蓋）
- 5/20 那 508 筆壞資料在重推前是否要先 archive，待討論

🤖 Generated with [Claude Code](https://claude.com/claude-code)