### PR TITLE
fix(knowledge): 分頁列從 overflow 容器移出

### DIFF
--- a/apps/web/src/app/dashboard/knowledge/page.tsx
+++ b/apps/web/src/app/dashboard/knowledge/page.tsx
@@ -197,28 +197,26 @@ export default function KnowledgePage() {
               </Tabs>
             </div>
 
-            <div className="flex-1 overflow-auto">
-              <ArticleList
-                articles={articles}
-                isLoading={isLoading}
-                onEdit={handleEdit}
-                onPublish={handlePublish}
-                onArchive={handleArchive}
-                onDelete={handleDelete}
-              />
-              {totalPages > 1 && (
-                <div className="flex items-center justify-between gap-4 border-t px-4 py-3">
-                  <span className="text-sm text-muted-foreground">
-                    共 {total} 篇 · 第 {page} / {totalPages} 頁
-                  </span>
-                  <Pagination
-                    page={page}
-                    totalPages={totalPages}
-                    onPageChange={setPage}
-                  />
-                </div>
-              )}
-            </div>
+            <ArticleList
+              articles={articles}
+              isLoading={isLoading}
+              onEdit={handleEdit}
+              onPublish={handlePublish}
+              onArchive={handleArchive}
+              onDelete={handleDelete}
+            />
+            {totalPages > 1 && (
+              <div className="flex items-center justify-between gap-4 border-t bg-background px-4 py-3">
+                <span className="text-sm text-muted-foreground">
+                  共 {total} 篇 · 第 {page} / {totalPages} 頁
+                </span>
+                <Pagination
+                  page={page}
+                  totalPages={totalPages}
+                  onPageChange={setPage}
+                />
+              </div>
+            )}
           </TabsContent>
 
           {/* ── Semantic Search Tab ───────────────────────────── */}


### PR DESCRIPTION
## Summary

修 PR #120 的視覺問題：分頁元件被滾動容器藏在表格底下，看起來像沒 render。

## 原因

PR #120 把分頁塞在 \`.flex-1.overflow-auto\` 內，526 筆資料下表格高度遠超螢幕，內部 scroll 把分頁推到看不見的位置（雖然 DOM 裡有，需要捲表格內部到底才看得到）。

驗證：console \`document.body.innerText.match(/共 \d+ 篇.*第.*頁/)\` 回 \`['共 526 篇 · 第 1 / 11 頁']\` — 分頁確實 render 了，只是視覺被擋住。

## Changes

把 \`ArticleList\` 與分頁列**直接放在 \`TabsContent\` 下**，拿掉外層 \`flex-1 overflow-auto\`。表格跟著瀏覽器整頁滾動，捲到底就看到分頁。

## Test plan

- [ ] 後台 \`/dashboard/knowledge\` 打開後直接看到完整表格 + 滾動到底看到分頁列「共 526 篇 · 第 1 / 11 頁」+ 頁碼按鈕
- [ ] 點頁碼能換頁、URL 不變但內容更新
- [ ] 切換 status / 分類 / 搜尋 → page 自動回 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)