### PR TITLE
fix(knowledge): 給 TabsContent 明確 viewport 高度讓分頁列釘底

### DIFF
--- a/apps/web/src/app/dashboard/knowledge/page.tsx
+++ b/apps/web/src/app/dashboard/knowledge/page.tsx
@@ -156,8 +156,18 @@ export default function KnowledgePage() {
           </TabsList>
 
           {/* ── Articles Tab ──────────────────────────────────── */}
-          <TabsContent value="articles">
-            <div className="border-b py-3">
+          {/*
+            Dashboard layout uses h-screen + overflow-hidden so we must
+            size this tab to the viewport explicitly (otherwise the table
+            overflows and the pagination row gets clipped off-screen).
+            Layout: filters / status tabs (fixed) → list (flex-1 scroll)
+            → pagination (shrink-0, pinned to bottom).
+          */}
+          <TabsContent
+            value="articles"
+            className="flex h-[calc(100vh-130px)] flex-col"
+          >
+            <div className="border-b py-3 shrink-0">
               <div className="flex items-center gap-3">
                 <SearchInput
                   placeholder="搜尋文章..."
@@ -185,7 +195,7 @@ export default function KnowledgePage() {
               </div>
             </div>
 
-            <div className="border-b pt-2">
+            <div className="border-b pt-2 shrink-0">
               <Tabs value={statusFilter} onValueChange={setStatusFilter}>
                 <TabsList>
                   {statusTabs.map((tab) => (
@@ -197,16 +207,18 @@ export default function KnowledgePage() {
               </Tabs>
             </div>
 
-            <ArticleList
-              articles={articles}
-              isLoading={isLoading}
-              onEdit={handleEdit}
-              onPublish={handlePublish}
-              onArchive={handleArchive}
-              onDelete={handleDelete}
-            />
+            <div className="flex-1 min-h-0 overflow-auto">
+              <ArticleList
+                articles={articles}
+                isLoading={isLoading}
+                onEdit={handleEdit}
+                onPublish={handlePublish}
+                onArchive={handleArchive}
+                onDelete={handleDelete}
+              />
+            </div>
             {totalPages > 1 && (
-              <div className="flex items-center justify-between gap-4 border-t bg-background px-4 py-3">
+              <div className="flex shrink-0 items-center justify-between gap-4 border-t bg-background px-4 py-3">
                 <span className="text-sm text-muted-foreground">
                   共 {total} 篇 · 第 {page} / {totalPages} 頁
                 </span>


### PR DESCRIPTION
## Summary

修 PR #121 失敗的視覺問題：分頁列確認 render 在 DOM 裡（console 抓得到），但被推到 viewport 外面看不到。

## 根因（這次有鐵證）

Dashboard layout 用 \`<div className=\"flex h-screen overflow-hidden\">\` + \`<main className=\"flex-1 overflow-hidden\">\` 把整頁固定在 viewport 高度、超出隱藏（\`app/dashboard/layout.tsx:36-38\`）。所以**子頁面整頁無法滾動**，每個內頁必須自己處理內部滾動。

PR #121 把 ArticleList 和分頁拉到 TabsContent 下，想跟整頁一起捲——但因為整頁根本不能捲，526 筆表格的高度超出 main overflow-hidden，分頁被推到視窗外。

驗證：

\`\`\`js
document.body.innerText.match(/共 \d+ 篇.*第.*頁/)
// → '共 526 篇 · 第 1 / 11 頁'   ← 在 DOM 裡
\`\`\`

同檔 embedding / chat tab 早就用 \`h-[calc(100vh-180px)] overflow-y-auto\` 繞過同樣問題。

## Changes

\`app/dashboard/knowledge/page.tsx\` 把 articles tab 改成：

\`\`\`
<TabsContent value=\"articles\" className=\"flex h-[calc(100vh-130px)] flex-col\">
  <div border-b shrink-0>filters</div>
  <div border-b shrink-0>status tabs</div>
  <div flex-1 min-h-0 overflow-auto>
    <ArticleList />              ← 自己捲
  </div>
  <div shrink-0 border-t>共 X 篇·第 N/M 頁 + Pagination</div>  ← 釘底
</TabsContent>
\`\`\`

## Test plan

- [ ] \`/dashboard/knowledge\` 打開立刻看到底部分頁列（不需捲動）
- [ ] 表格內捲動，分頁列保持釘在底部
- [ ] 點頁碼能換頁
- [ ] 切換 status / 分類 / 搜尋 → page 回 1
- [ ] 切到「語義搜尋」/ 「Embedding 設定」/「Chat & Prompt」tab 排版不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)