### PR TITLE
fix(automation): updateRule 純改 metadata 不再跑 contract 驗證

### DIFF
--- a/apps/api/src/modules/automation/automation.service.ts
+++ b/apps/api/src/modules/automation/automation.service.ts
@@ -139,13 +139,23 @@ export async function updateRule(
     throw new AppError('Automation rule not found', 'NOT_FOUND', 404);
   }
 
-  const existingTrigger = existing.trigger as Record<string, unknown>;
-  const nextEventType = String(
-    data.trigger?.type ?? existingTrigger?.type ?? existing.eventType ?? '',
-  );
-  const nextConditions = data.conditions ?? (existing.conditions as Record<string, unknown>);
-  const nextActions = data.actions ?? (existing.actions as Array<Record<string, unknown>>);
-  validateRuleContract(nextEventType, nextConditions, nextActions);
+  // 只在 caller 實際改動 trigger / conditions / actions 時才驗證 contract。
+  // 純改 isActive / name / priority 等 metadata 不該被既有不合法的 actions 卡住
+  // （contract 規則會演進，舊資料可能不合新版規則，但不該因此連停用都不能做）。
+  const touchesContract =
+    data.trigger !== undefined ||
+    data.conditions !== undefined ||
+    data.actions !== undefined;
+
+  if (touchesContract) {
+    const existingTrigger = existing.trigger as Record<string, unknown>;
+    const nextEventType = String(
+      data.trigger?.type ?? existingTrigger?.type ?? existing.eventType ?? '',
+    );
+    const nextConditions = data.conditions ?? (existing.conditions as Record<string, unknown>);
+    const nextActions = data.actions ?? (existing.actions as Array<Record<string, unknown>>);
+    validateRuleContract(nextEventType, nextConditions, nextActions);
+  }
 
   const updateData: Prisma.AutomationRuleUpdateInput = {};
   if (data.name !== undefined) updateData.name = data.name;


### PR DESCRIPTION
## Summary

- DB 內既有規則若含舊版 contract 不合法的 action（例如 `message.received` 配 `auto_assign`），會導致連單純切 `isActive=false` 也被 contract validation 擋下，使用者無法停用該規則
- 修法：`updateRule` 改成只在 caller 真的送 `trigger / conditions / actions` 任一個時才呼叫 `validateRuleContract`，純改 `isActive / name / priority / description / stopOnMatch` 等 metadata 跳過驗證

## Test plan

- [x] api typecheck pass (`pnpm --filter @open333crm/api exec tsc --noEmit`)
- [ ] 部署到 UAT 後，到自動化頁列表，點某條既有 `auto_assign` 規則的「停用」按鈕，預期 toggle 成功（不再噴 `actions[1].type is not allowed for message.received: auto_assign`）
- [ ] 既有 PATCH 含 actions 的編輯流程仍會走 contract 驗證（regression）

🤖 Generated with [Claude Code](https://claude.com/claude-code)