### PR TITLE
feat(line+kb): LINE quick reply / 關鍵字回覆 / KB 回答品質回報

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -38,6 +38,7 @@ import slaRoutes from './modules/sla/sla.routes.js';
 import lineLoginRoutes from './modules/line-login/line-login.routes.js';
 import lineProfileRoutes from './modules/line/line-profile.routes.js';
 import richMenuRoutes from './modules/line/rich-menu.routes.js';
+import quickReplyPresetRoutes from './modules/line/quick-reply-preset.routes.js';
 import fbLoginRoutes from './modules/fb-login/fb-login.routes.js';
 import notificationRoutes from './modules/notification/notification.routes.js';
 import analyticsRoutes from './modules/analytics/analytics.routes.js';
@@ -123,6 +124,7 @@ export async function bootstrap() {
   await app.register(lineLoginRoutes, { prefix: '/api/v1/auth/line' });
   await app.register(lineProfileRoutes, { prefix: '/api/v1' });
   await app.register(richMenuRoutes, { prefix: '/api/v1/line/rich-menus' });
+  await app.register(quickReplyPresetRoutes, { prefix: '/api/v1/line/quick-reply-presets' });
   await app.register(fbLoginRoutes, { prefix: '/api/v1/auth/fb' });
   await app.register(notificationRoutes, { prefix: '/api/v1/notifications' });
   await app.register(analyticsRoutes, { prefix: '/api/v1/analytics' });

--- a/apps/api/src/modules/ai/kb-autoreply.service.ts
+++ b/apps/api/src/modules/ai/kb-autoreply.service.ts
@@ -22,6 +22,7 @@ import { getChatSettings } from '../settings/chat-settings.service.js';
 import { generateReply, CLARIFY_SYSTEM_PROMPT } from './llm.service.js';
 import type { HistoryMessage } from './llm.service.js';
 import { deliverToChannel } from '../conversation/conversation.service.js';
+import { hasMatchingKeywordRule } from '../automation/automation.worker.js';
 import { logger } from '@open333crm/core';
 
 const HANDOFF_PROMPT = '需要真人客服協助嗎？請輸入「真人」或「客服」即可轉接。';
@@ -42,6 +43,13 @@ export async function attemptKbAutoReply(
 
   // 1. Global enable check
   if (!config.KB_AUTO_REPLY_ENABLED) return false;
+
+  // 1.5 若有 keyword.matched 規則命中此訊息，讓步給 keyword 規則處理。
+  // 避免 KB 走 clarify_handoff 把對話改成 AGENT_HANDLED，後續 keyword rule 觸發後也無法回。
+  if (await hasMatchingKeywordRule(prisma, tenantId, messageText)) {
+    logger.info(`[KbAutoReply] conv=${conversationId} skipped: keyword rule will handle`);
+    return false;
+  }
 
   // 2. Only proceed for BOT_HANDLED conversations
   const conversation = await prisma.conversation.findFirst({
@@ -203,7 +211,25 @@ export async function attemptKbAutoReply(
   io.to(`tenant:${tenantId}`).emit('message.new', wsPayload);
 
   // 12. Deliver to actual channel
-  await deliverToChannel(prisma, conversationId, replyText);
+  // 命中 KB 的回答附「👎 沒幫到我」回報按鈕（quick reply postback），供調教 KB。
+  // clarify / clarify_handoff 那種沒命中 KB 的不附（沒對應文章可回報）。
+  const hitKb = replyKind === 'kb_high_confidence' || replyKind === 'kb_with_handoff';
+  if (hitKb && topResult?.id) {
+    await deliverToChannel(prisma, conversationId, {
+      contentType: 'text',
+      content: {
+        text: replyText,
+        quickReplies: [
+          {
+            label: '👎 沒幫到我',
+            postbackData: `kb_feedback:bad:${topResult.id}:${botMessage.id}`,
+          },
+        ],
+      },
+    });
+  } else {
+    await deliverToChannel(prisma, conversationId, replyText);
+  }
 
   logger.info(
     `[KbAutoReply] conv=${conversationId} kind=${replyKind} sim=${topSimilarity.toFixed(3)}`,

--- a/apps/api/src/modules/automation/automation.worker.ts
+++ b/apps/api/src/modules/automation/automation.worker.ts
@@ -17,10 +17,18 @@ import { classifyIssue } from '../ai/classify.service.js';
 import { deliverToChannel } from '../conversation/conversation.service.js';
 import { logger } from '@open333crm/core';
 
-const automationQueue = new Queue('automation', {
-  connection: { url: process.env.REDIS_URL! },
-  defaultJobOptions: { removeOnComplete: 100, removeOnFail: 50 },
-});
+// Lazy init：避免在 dotenv 載入前讀到 undefined REDIS_URL，
+// ioredis fallback default 6379 會噴一堆 ECONNREFUSED 噪音
+let _automationQueue: Queue | null = null;
+function automationQueue(): Queue {
+  if (!_automationQueue) {
+    _automationQueue = new Queue('automation', {
+      connection: { url: process.env.REDIS_URL! },
+      defaultJobOptions: { removeOnComplete: 100, removeOnFail: 50 },
+    });
+  }
+  return _automationQueue;
+}
 
 interface BotConfig {
   botMode: 'keyword' | 'llm' | 'keyword_then_llm' | 'off';
@@ -183,6 +191,41 @@ async function checkAutoHandoff(
 }
 
 /**
+ * Pure check：訊息文字有沒有命中任何 active keyword.matched rule。
+ * 給 kb-autoreply 前置判斷用（命中就讓 keyword 規則處理，不走 KB）。
+ */
+export async function hasMatchingKeywordRule(
+  prisma: PrismaClient,
+  tenantId: string,
+  messageText: string,
+): Promise<boolean> {
+  if (!messageText) return false;
+  const rules = await prisma.automationRule.findMany({
+    where: { tenantId, isActive: true },
+  });
+  const keywordRules = rules.filter((rule) => {
+    const trigger = rule.trigger as Record<string, unknown>;
+    return trigger?.type === 'keyword.matched';
+  });
+  if (keywordRules.length === 0) return false;
+
+  const lowerText = messageText.toLowerCase();
+  for (const rule of keywordRules) {
+    const trigger = rule.trigger as Record<string, unknown>;
+    const keywords = (trigger.keywords as string[]) || [];
+    const matchMode = (trigger.match_mode as string) || 'any';
+    if (keywords.length === 0) continue;
+
+    const matched =
+      matchMode === 'all'
+        ? keywords.every((kw) => lowerText.includes(kw.toLowerCase()))
+        : keywords.some((kw) => lowerText.includes(kw.toLowerCase()));
+    if (matched) return true;
+  }
+  return false;
+}
+
+/**
  * Check if a message matches keyword.matched rules and publish events.
  */
 async function checkKeywordTriggers(
@@ -321,7 +364,7 @@ export function setupAutomationWorker(prisma: PrismaClient, io: Server) {
         }
       }
 
-      await automationQueue.add('automation:evaluate', {
+      await automationQueue().add('automation:evaluate', {
         tenantId: event.tenantId,
         trigger: 'message.received',
         context: { contactId, conversationId, messageContent: text },
@@ -349,7 +392,7 @@ export function setupAutomationWorker(prisma: PrismaClient, io: Server) {
         messageContent?: string;
       };
 
-      await automationQueue.add('automation:evaluate', {
+      await automationQueue().add('automation:evaluate', {
         tenantId: event.tenantId,
         trigger: 'keyword.matched',
         context: { contactId, conversationId, messageContent },
@@ -368,7 +411,7 @@ export function setupAutomationWorker(prisma: PrismaClient, io: Server) {
         caseId?: string;
       };
 
-      await automationQueue.add('automation:evaluate', {
+      await automationQueue().add('automation:evaluate', {
         tenantId: event.tenantId,
         trigger: 'case.created',
         context: { contactId, conversationId, caseId },
@@ -408,7 +451,7 @@ export function setupAutomationWorker(prisma: PrismaClient, io: Server) {
         conversationId?: string;
       };
 
-      await automationQueue.add('automation:evaluate', {
+      await automationQueue().add('automation:evaluate', {
         tenantId: event.tenantId,
         trigger: 'conversation.created',
         context: { contactId, conversationId },
@@ -425,7 +468,7 @@ export function setupAutomationWorker(prisma: PrismaClient, io: Server) {
         contactId?: string;
       };
 
-      await automationQueue.add('automation:evaluate', {
+      await automationQueue().add('automation:evaluate', {
         tenantId: event.tenantId,
         trigger: 'contact.tagged',
         context: { contactId },
@@ -444,7 +487,7 @@ export function setupAutomationWorker(prisma: PrismaClient, io: Server) {
         caseId?: string;
       };
 
-      await automationQueue.add('automation:evaluate', {
+      await automationQueue().add('automation:evaluate', {
         tenantId: event.tenantId,
         trigger: 'case.escalated',
         context: { contactId, conversationId, caseId },
@@ -462,7 +505,7 @@ export function setupAutomationWorker(prisma: PrismaClient, io: Server) {
         activityId?: string;
       };
 
-      await automationQueue.add('automation:evaluate', {
+      await automationQueue().add('automation:evaluate', {
         tenantId: event.tenantId,
         trigger: 'portal.activity.submitted',
         context: { contactId, activityId },
@@ -480,7 +523,7 @@ export function setupAutomationWorker(prisma: PrismaClient, io: Server) {
         shortLinkId?: string;
       };
 
-      await automationQueue.add('automation:evaluate', {
+      await automationQueue().add('automation:evaluate', {
         tenantId: event.tenantId,
         trigger: 'link.clicked',
         context: { contactId, shortLinkId },

--- a/apps/api/src/modules/automation/engine/action-executor.ts
+++ b/apps/api/src/modules/automation/engine/action-executor.ts
@@ -14,15 +14,17 @@
  *   llm_reply          – LLM-generated reply
  *   update_case_status – Update a case's status
  *   escalate_case      – Escalate a case (priority bump + ESCALATED status)
+ *   send_material      – Send a Material/Template (image, video, flex, carousel, ...)
  */
 
-import type { PrismaClient } from '@prisma/client';
+import type { PrismaClient, Prisma } from '@prisma/client';
 import type { Server } from 'socket.io';
 import type { ConversationUpdatedPayload } from '@open333crm/shared';
 import { attemptKbAutoReply } from '../../ai/kb-autoreply.service.js';
 import { deliverToChannel } from '../../conversation/conversation.service.js';
 import { generateReply } from '../../ai/llm.service.js';
 import { autoAssignCase } from '../../case/assignment.service.js';
+import { renderTemplateBody } from '../../marketing/template-renderer.js';
 import { logger } from '@open333crm/core';
 
 export interface ActionPayload {
@@ -45,7 +47,7 @@ export interface ActionContext {
 }
 
 // Actions that send outbound messages to the contact
-const OUTBOUND_ACTIONS = new Set(['send_message', 'llm_reply', 'kb_auto_reply']);
+const OUTBOUND_ACTIONS = new Set(['send_message', 'llm_reply', 'kb_auto_reply', 'send_material']);
 
 // Tags that indicate opt-out / do-not-disturb
 const OPT_OUT_TAGS = ['do_not_disturb', 'opt_out', '勿擾', '退訂'];
@@ -139,6 +141,12 @@ export async function executeActions(
 
         case 'send_message': {
           const result = await handleSendMessage(prisma, io, context, action.params);
+          results.push({ action: action.type, success: true, data: result });
+          break;
+        }
+
+        case 'send_material': {
+          const result = await handleSendMaterial(prisma, io, context, action.params);
           results.push({ action: action.type, success: true, data: result });
           break;
         }
@@ -490,6 +498,84 @@ async function handleSendMessage(
   await deliverToChannel(prisma, context.conversationId, text);
 
   return { messageId: message.id };
+}
+
+/**
+ * Send a Material/Template (image, video, flex, carousel, ...) as bot reply.
+ * params: { materialId: string, variables?: Record<string, string> }
+ *
+ * - materialId 來自 Material 表（marketing/materials 庫）
+ * - 若 material.body 含 {{key}} 變數，會用 params.variables map 渲染
+ * - contentType 沿用 material.contentType（line_text / line_image / line_carousel / ...）
+ */
+async function handleSendMaterial(
+  prisma: PrismaClient,
+  io: Server,
+  context: ActionContext,
+  params: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  if (!context.conversationId) {
+    throw new Error('Cannot send material: no conversationId in context');
+  }
+  const materialId = params.materialId as string;
+  if (!materialId) {
+    throw new Error('Cannot send material: materialId not specified');
+  }
+
+  const material = await prisma.material.findFirst({
+    where: { id: materialId, tenantId: context.tenantId },
+    select: { id: true, contentType: true, body: true, channelType: true },
+  });
+  if (!material) {
+    throw new Error(`Material ${materialId} not found`);
+  }
+
+  const variables = (params.variables as Record<string, string> | undefined) ?? {};
+  const renderedBody = renderTemplateBody(
+    material.body as Record<string, unknown>,
+    variables,
+  );
+
+  // 1. 寫 outbound message 進 DB（給對話歷史看）
+  const message = await prisma.message.create({
+    data: {
+      conversationId: context.conversationId,
+      direction: 'OUTBOUND',
+      senderType: 'SYSTEM',
+      contentType: material.contentType,
+      content: renderedBody as unknown as Prisma.InputJsonValue,
+      metadata: { source: 'automation', materialId, source_type: 'send_material' },
+    },
+  });
+
+  await prisma.conversation.update({
+    where: { id: context.conversationId },
+    data: { lastMessageAt: new Date() },
+  });
+
+  // 2. WebSocket 推給 UI
+  const wsPayload = {
+    conversationId: context.conversationId,
+    message: {
+      id: message.id,
+      conversationId: context.conversationId,
+      direction: 'OUTBOUND',
+      senderType: 'SYSTEM',
+      contentType: material.contentType,
+      content: renderedBody,
+      createdAt: message.createdAt.toISOString(),
+    },
+  };
+  io.to(`conversation:${context.conversationId}`).emit('message.new', wsPayload);
+  io.to(`tenant:${context.tenantId}`).emit('message.new', wsPayload);
+
+  // 3. 送出 channel（image / flex / carousel 等都靠 plugin.sendMessage 處理）
+  await deliverToChannel(prisma, context.conversationId, {
+    contentType: material.contentType,
+    content: renderedBody,
+  });
+
+  return { messageId: message.id, materialId };
 }
 
 async function handleAssignAgent(

--- a/apps/api/src/modules/conversation/conversation.service.ts
+++ b/apps/api/src/modules/conversation/conversation.service.ts
@@ -568,11 +568,20 @@ function getRedisPub(): IORedis {
  * For WEBCHAT, also pushes the message to the visitor's Socket.IO room via Redis bridge.
  * Non-fatal: errors are logged but not thrown.
  */
+/**
+ * 把訊息送出 channel。
+ * - 傳 string → 當純文字送
+ * - 傳 { contentType, content } → 用該 payload 送（例如素材：圖、影片、Flex、Carousel）
+ */
 export async function deliverToChannel(
   prisma: PrismaClient,
   conversationId: string,
-  text: string,
+  payload: string | { contentType: string; content: Record<string, unknown> },
 ): Promise<void> {
+  const outbound = typeof payload === 'string'
+    ? { contentType: 'text', content: { text: payload } as Record<string, unknown> }
+    : payload;
+
   try {
     const conv = await prisma.conversation.findUnique({
       where: { id: conversationId },
@@ -605,10 +614,10 @@ export async function deliverToChannel(
       return;
     }
 
-    logger.info(`[deliverToChannel] Sending to ${conv.channel.channelType} uid=${identity.uid}`);
+    logger.info(`[deliverToChannel] Sending to ${conv.channel.channelType} uid=${identity.uid} contentType=${outbound.contentType}`);
     const result = await plugin.sendMessage(
       identity.uid,
-      { contentType: 'text', content: { text } },
+      outbound,
       credentials,
     );
     logger.info(`[deliverToChannel] Sent successfully to uid=${identity.uid}`);
@@ -617,10 +626,10 @@ export async function deliverToChannel(
     if (conv.channel.channelType === CHANNEL_TYPE.WEBCHAT) {
       const room = `visitor:${conv.channel.id}:${identity.uid}`;
       const msgPayload = {
-        contentType: 'text',
-        content: { text },
-        type: 'text',
-        payload: { text },
+        contentType: outbound.contentType,
+        content: outbound.content,
+        type: outbound.contentType,
+        payload: outbound.content,
         direction: 'OUTBOUND',
         senderType: 'BOT',
         channelMsgId: result?.channelMsgId,

--- a/apps/api/src/modules/knowledge/kb-feedback.service.ts
+++ b/apps/api/src/modules/knowledge/kb-feedback.service.ts
@@ -1,0 +1,153 @@
+/**
+ * KB Article Feedback service — AI 回答品質回饋迴路。
+ *
+ * 測試者/用戶在 LINE 點「👎 沒幫到我」→ 記下「問句 + 命中的 KB 文章」→
+ * 後台知識庫頁顯示被回報次數，客服據此調教 KB content。
+ */
+
+import type { PrismaClient } from '@prisma/client';
+import { AppError } from '../../shared/utils/response.js';
+import { logger } from '@open333crm/core';
+
+export interface RecordFeedbackInput {
+  rating: 'bad' | 'good';
+  articleId: string; // 'none' 代表當時沒命中 KB
+  messageId: string; // bot 那則回覆的 message id
+  contactId?: string;
+}
+
+/**
+ * 記錄一筆回報。會從 messageId 反查 bot 回覆 + 往前抓最近一則 inbound 當問句。
+ */
+export async function recordKbFeedback(
+  prisma: PrismaClient,
+  tenantId: string,
+  input: RecordFeedbackInput,
+): Promise<void> {
+  if (input.articleId === 'none') {
+    logger.info('[KbFeedback] skipped: no KB article hit (articleId=none)');
+    return;
+  }
+
+  // 反查 bot 訊息（拿 conversation + metadata confidence + 回答快照）
+  const botMsg = await prisma.message.findFirst({
+    where: { id: input.messageId },
+    select: {
+      conversationId: true,
+      content: true,
+      metadata: true,
+      createdAt: true,
+    },
+  });
+
+  let userQuestion: string | null = null;
+  let botReply: string | null = null;
+  let confidence: number | null = null;
+
+  if (botMsg) {
+    botReply = ((botMsg.content as Record<string, unknown>)?.text as string) ?? null;
+    confidence = ((botMsg.metadata as Record<string, unknown>)?.confidence as number) ?? null;
+
+    // 往前抓最近一則 inbound（使用者問句）
+    const inbound = await prisma.message.findFirst({
+      where: {
+        conversationId: botMsg.conversationId,
+        direction: 'INBOUND',
+        createdAt: { lt: botMsg.createdAt },
+      },
+      orderBy: { createdAt: 'desc' },
+      select: { content: true },
+    });
+    userQuestion = ((inbound?.content as Record<string, unknown>)?.text as string) ?? null;
+  }
+
+  // 確認 article 屬於此 tenant（避免跨租戶汙染）
+  const article = await prisma.kmArticle.findFirst({
+    where: { id: input.articleId, tenantId },
+    select: { id: true },
+  });
+  if (!article) {
+    logger.warn(`[KbFeedback] article ${input.articleId} not found for tenant ${tenantId}, skip`);
+    return;
+  }
+
+  await prisma.kbArticleFeedback.create({
+    data: {
+      tenantId,
+      articleId: input.articleId,
+      messageId: input.messageId,
+      userQuestion,
+      botReply,
+      confidence,
+      rating: input.rating,
+      contactId: input.contactId ?? null,
+      status: 'open',
+    },
+  });
+
+  logger.info(
+    `[KbFeedback] recorded ${input.rating} for article=${input.articleId} q="${userQuestion?.slice(0, 30) ?? '?'}"`,
+  );
+}
+
+/**
+ * 列出回報（後台用）。可依 articleId / status 過濾。
+ */
+export async function listFeedback(
+  prisma: PrismaClient,
+  tenantId: string,
+  filter: { articleId?: string; status?: string } = {},
+) {
+  return prisma.kbArticleFeedback.findMany({
+    where: {
+      tenantId,
+      ...(filter.articleId ? { articleId: filter.articleId } : {}),
+      ...(filter.status ? { status: filter.status } : {}),
+    },
+    orderBy: { createdAt: 'desc' },
+    include: {
+      article: { select: { id: true, title: true, externalDocId: true } },
+    },
+  });
+}
+
+/**
+ * 各文章的 open 回報數 map（給知識庫列表頁顯示 badge）。
+ * 回傳 { [articleId]: openCount }
+ */
+export async function getFeedbackCounts(
+  prisma: PrismaClient,
+  tenantId: string,
+): Promise<Record<string, number>> {
+  const rows = await prisma.kbArticleFeedback.groupBy({
+    by: ['articleId'],
+    where: { tenantId, status: 'open' },
+    _count: { _all: true },
+  });
+  const map: Record<string, number> = {};
+  for (const r of rows) {
+    map[r.articleId] = r._count._all;
+  }
+  return map;
+}
+
+/**
+ * 標記回報為已處理。
+ */
+export async function resolveFeedback(
+  prisma: PrismaClient,
+  id: string,
+  tenantId: string,
+): Promise<void> {
+  const existing = await prisma.kbArticleFeedback.findFirst({
+    where: { id, tenantId },
+    select: { id: true },
+  });
+  if (!existing) {
+    throw new AppError('回報記錄不存在', 'NOT_FOUND', 404);
+  }
+  await prisma.kbArticleFeedback.update({
+    where: { id },
+    data: { status: 'resolved' },
+  });
+}

--- a/apps/api/src/modules/knowledge/kb-feedback.service.ts
+++ b/apps/api/src/modules/knowledge/kb-feedback.service.ts
@@ -29,9 +29,10 @@ export async function recordKbFeedback(
     return;
   }
 
-  // 反查 bot 訊息（拿 conversation + metadata confidence + 回答快照）
+  // 反查 bot 訊息（拿 conversation + metadata confidence + 回答快照）。
+  // 透過 conversation.tenantId 限定租戶，避免跨租戶讀到他人對話內容。
   const botMsg = await prisma.message.findFirst({
-    where: { id: input.messageId },
+    where: { id: input.messageId, conversation: { tenantId } },
     select: {
       conversationId: true,
       content: true,

--- a/apps/api/src/modules/knowledge/knowledge.routes.ts
+++ b/apps/api/src/modules/knowledge/knowledge.routes.ts
@@ -21,6 +21,11 @@ import {
   parseCmd,
   type PartnerAttachmentInput,
 } from './partner-ingest.service.js';
+import {
+  listFeedback,
+  getFeedbackCounts,
+  resolveFeedback,
+} from './kb-feedback.service.js';
 import { requireSupervisor } from '../../guards/rbac.guard.js';
 import { AppError, success, paginated } from '../../shared/utils/response.js';
 
@@ -297,6 +302,34 @@ export default async function knowledgeRoutes(fastify: FastifyInstance) {
     const status = await checkOllamaHealth(fastify.prisma, request.agent.tenantId);
     return reply.send(success(status));
   });
+
+  // ── KB 回報（AI 回答品質回饋）────────────────────────────────────────────
+
+  // GET /api/v1/knowledge/feedback/counts — 各文章 open 回報數 map
+  fastify.get('/feedback/counts', async (request, reply) => {
+    const counts = await getFeedbackCounts(fastify.prisma, request.agent.tenantId);
+    return reply.send(success(counts));
+  });
+
+  // GET /api/v1/knowledge/feedback?articleId=&status=open — 回報明細
+  fastify.get('/feedback', async (request, reply) => {
+    const q = request.query as { articleId?: string; status?: string };
+    const list = await listFeedback(fastify.prisma, request.agent.tenantId, {
+      articleId: q.articleId,
+      status: q.status,
+    });
+    return reply.send(success(list));
+  });
+
+  // PATCH /api/v1/knowledge/feedback/:id/resolve — 標記已處理
+  fastify.patch<{ Params: { id: string } }>(
+    '/feedback/:id/resolve',
+    { preHandler: [requireSupervisor()] },
+    async (request, reply) => {
+      await resolveFeedback(fastify.prisma, request.params.id, request.agent.tenantId);
+      return reply.send(success({ resolved: true }));
+    },
+  );
 
   // ── Existing CRUD routes ──────────────────────────────────────────────────
 

--- a/apps/api/src/modules/line/quick-reply-preset.routes.ts
+++ b/apps/api/src/modules/line/quick-reply-preset.routes.ts
@@ -1,0 +1,78 @@
+/**
+ * Quick Reply Preset routes
+ *
+ * 前綴：/api/v1/line/quick-reply-presets
+ * 列表（GET /）所有登入 agent 可讀（客服選 preset 用）；其他寫操作需 SUPERVISOR 以上
+ */
+
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import {
+  listPresets,
+  createPreset,
+  updatePreset,
+  deletePreset,
+} from './quick-reply-preset.service.js';
+import { success } from '../../shared/utils/response.js';
+import { requireSupervisor } from '../../guards/rbac.guard.js';
+
+const itemSchema = z.object({
+  label: z.string().min(1).max(20),
+  text: z.string().min(1).max(300).optional(),
+});
+
+const createSchema = z.object({
+  name: z.string().min(1).max(100),
+  items: z.array(itemSchema).min(1).max(13),
+});
+
+const updateSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  items: z.array(itemSchema).min(1).max(13).optional(),
+  isActive: z.boolean().optional(),
+});
+
+export default async function quickReplyPresetRoutes(fastify: FastifyInstance) {
+  fastify.addHook('preHandler', fastify.authenticate);
+
+  // GET /api/v1/line/quick-reply-presets — 任何登入 agent 可讀
+  fastify.get('/', async (request, reply) => {
+    const list = await listPresets(fastify.prisma, request.agent.tenantId);
+    return reply.send(success(list));
+  });
+
+  // 以下寫操作限 SUPERVISOR
+  fastify.post('/', { preHandler: [requireSupervisor()] }, async (request, reply) => {
+    const data = createSchema.parse(request.body);
+    const preset = await createPreset(fastify.prisma, request.agent.tenantId, data);
+    return reply.code(201).send(success(preset));
+  });
+
+  fastify.patch<{ Params: { id: string } }>(
+    '/:id',
+    { preHandler: [requireSupervisor()] },
+    async (request, reply) => {
+      const data = updateSchema.parse(request.body);
+      const preset = await updatePreset(
+        fastify.prisma,
+        request.params.id,
+        request.agent.tenantId,
+        data,
+      );
+      return reply.send(success(preset));
+    },
+  );
+
+  fastify.delete<{ Params: { id: string } }>(
+    '/:id',
+    { preHandler: [requireSupervisor()] },
+    async (request, reply) => {
+      const result = await deletePreset(
+        fastify.prisma,
+        request.params.id,
+        request.agent.tenantId,
+      );
+      return reply.send(success(result));
+    },
+  );
+}

--- a/apps/api/src/modules/line/quick-reply-preset.service.ts
+++ b/apps/api/src/modules/line/quick-reply-preset.service.ts
@@ -49,10 +49,10 @@ function validateItems(items: QuickReplyItem[]): void {
 }
 
 function validateName(name: string): void {
-  if (!name || name.length === 0) {
+  if (!name || name.trim().length === 0) {
     throw new AppError('名稱不能為空', 'INVALID_INPUT', 400);
   }
-  if (name.length > 100) {
+  if (name.trim().length > 100) {
     throw new AppError('名稱不能超過 100 字', 'INVALID_INPUT', 400);
   }
 }
@@ -80,7 +80,7 @@ export async function createPreset(
   return prisma.quickReplyPreset.create({
     data: {
       tenantId,
-      name: input.name,
+      name: input.name.trim(),
       items: input.items as unknown as Prisma.InputJsonValue,
     },
   });
@@ -97,7 +97,7 @@ export async function updatePreset(
   if (input.items !== undefined) validateItems(input.items);
 
   const data: Prisma.QuickReplyPresetUpdateInput = {};
-  if (input.name !== undefined) data.name = input.name;
+  if (input.name !== undefined) data.name = input.name.trim();
   if (input.items !== undefined) data.items = input.items as unknown as Prisma.InputJsonValue;
   if (input.isActive !== undefined) data.isActive = input.isActive;
 

--- a/apps/api/src/modules/line/quick-reply-preset.service.ts
+++ b/apps/api/src/modules/line/quick-reply-preset.service.ts
@@ -1,0 +1,111 @@
+/**
+ * Quick Reply Preset service — 客服可重用的快速回覆按鈕組。
+ * Tenant-scoped；不綁定特定 channel（所有 LINE channel 共用同一組 preset）。
+ */
+
+import type { PrismaClient, Prisma } from '@prisma/client';
+import { AppError } from '../../shared/utils/response.js';
+
+export interface QuickReplyItem {
+  label: string;
+  text?: string;
+}
+
+export interface CreatePresetInput {
+  name: string;
+  items: QuickReplyItem[];
+}
+
+export interface UpdatePresetInput {
+  name?: string;
+  items?: QuickReplyItem[];
+  isActive?: boolean;
+}
+
+// LINE 規格：≤ 13 個 item；label ≤ 20 chars；text ≤ 300 chars
+function validateItems(items: QuickReplyItem[]): void {
+  if (!Array.isArray(items) || items.length === 0) {
+    throw new AppError('至少需要 1 個按鈕', 'INVALID_INPUT', 400);
+  }
+  if (items.length > 13) {
+    throw new AppError('最多 13 個按鈕（LINE 限制）', 'INVALID_INPUT', 400);
+  }
+  for (const [i, it] of items.entries()) {
+    if (!it.label || typeof it.label !== 'string' || it.label.length === 0) {
+      throw new AppError(`第 ${i + 1} 個按鈕缺少 label`, 'INVALID_INPUT', 400);
+    }
+    if (it.label.length > 20) {
+      throw new AppError(`第 ${i + 1} 個按鈕 label 超過 20 字`, 'INVALID_INPUT', 400);
+    }
+    if (it.text !== undefined && it.text !== null) {
+      if (typeof it.text !== 'string') {
+        throw new AppError(`第 ${i + 1} 個按鈕 text 格式錯誤`, 'INVALID_INPUT', 400);
+      }
+      if (it.text.length > 300) {
+        throw new AppError(`第 ${i + 1} 個按鈕 text 超過 300 字`, 'INVALID_INPUT', 400);
+      }
+    }
+  }
+}
+
+function validateName(name: string): void {
+  if (!name || name.length === 0) {
+    throw new AppError('名稱不能為空', 'INVALID_INPUT', 400);
+  }
+  if (name.length > 100) {
+    throw new AppError('名稱不能超過 100 字', 'INVALID_INPUT', 400);
+  }
+}
+
+export async function listPresets(prisma: PrismaClient, tenantId: string) {
+  return prisma.quickReplyPreset.findMany({
+    where: { tenantId, isActive: true },
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+export async function getPreset(prisma: PrismaClient, id: string, tenantId: string) {
+  const preset = await prisma.quickReplyPreset.findFirst({ where: { id, tenantId } });
+  if (!preset) throw new AppError('預設組不存在', 'NOT_FOUND', 404);
+  return preset;
+}
+
+export async function createPreset(
+  prisma: PrismaClient,
+  tenantId: string,
+  input: CreatePresetInput,
+) {
+  validateName(input.name);
+  validateItems(input.items);
+  return prisma.quickReplyPreset.create({
+    data: {
+      tenantId,
+      name: input.name,
+      items: input.items as unknown as Prisma.InputJsonValue,
+    },
+  });
+}
+
+export async function updatePreset(
+  prisma: PrismaClient,
+  id: string,
+  tenantId: string,
+  input: UpdatePresetInput,
+) {
+  await getPreset(prisma, id, tenantId);
+  if (input.name !== undefined) validateName(input.name);
+  if (input.items !== undefined) validateItems(input.items);
+
+  const data: Prisma.QuickReplyPresetUpdateInput = {};
+  if (input.name !== undefined) data.name = input.name;
+  if (input.items !== undefined) data.items = input.items as unknown as Prisma.InputJsonValue;
+  if (input.isActive !== undefined) data.isActive = input.isActive;
+
+  return prisma.quickReplyPreset.update({ where: { id }, data });
+}
+
+export async function deletePreset(prisma: PrismaClient, id: string, tenantId: string) {
+  await getPreset(prisma, id, tenantId);
+  await prisma.quickReplyPreset.delete({ where: { id } });
+  return { deleted: true };
+}

--- a/apps/api/src/modules/line/rich-menu.routes.ts
+++ b/apps/api/src/modules/line/rich-menu.routes.ts
@@ -14,6 +14,8 @@ import {
   updateRichMenu,
   deleteRichMenu,
   duplicateRichMenu,
+  publishRichMenu,
+  unpublishRichMenu,
 } from './rich-menu.service.js';
 import { success } from '../../shared/utils/response.js';
 import { requireSupervisor } from '../../guards/rbac.guard.js';
@@ -119,5 +121,17 @@ export default async function richMenuRoutes(fastify: FastifyInstance) {
   fastify.post<{ Params: { id: string } }>('/:id/duplicate', async (request, reply) => {
     const menu = await duplicateRichMenu(fastify.prisma, request.params.id, request.agent.tenantId);
     return reply.code(201).send(success(menu));
+  });
+
+  // POST /api/v1/line/rich-menus/:id/publish
+  fastify.post<{ Params: { id: string } }>('/:id/publish', async (request, reply) => {
+    const menu = await publishRichMenu(fastify.prisma, request.params.id, request.agent.tenantId);
+    return reply.send(success(menu));
+  });
+
+  // POST /api/v1/line/rich-menus/:id/unpublish
+  fastify.post<{ Params: { id: string } }>('/:id/unpublish', async (request, reply) => {
+    const menu = await unpublishRichMenu(fastify.prisma, request.params.id, request.agent.tenantId);
+    return reply.send(success(menu));
   });
 }

--- a/apps/api/src/modules/line/rich-menu.service.ts
+++ b/apps/api/src/modules/line/rich-menu.service.ts
@@ -1,16 +1,15 @@
 /**
- * Rich Menu 草稿管理 service
+ * Rich Menu 管理 service
  *
- * 本期只做 CRUD：
- *   - status 一律 draft（更新 / 刪除前 service 層強制驗證）
- *   - 未來 publish 流程接手時，會擴 status 到 published / error
- *
- * 與 LINE API 互動（POST richmenu / 上傳圖檔 / set default 等）由後續迭代負責。
+ * CRUD：status 一律 draft；published 的 menu 不能直接改 / 刪，需先 unpublish。
+ * Publish 流程：建 LINE richmenu → 上傳圖 → 若 selected 則 set as default。
  */
 
 import type { PrismaClient, Prisma } from '@prisma/client';
 import { AppError } from '../../shared/utils/response.js';
+import { logger } from '@open333crm/core';
 import { isValidRichMenuSize } from './rich-menu.layouts.js';
+import { decryptCredentials } from '../channel/channel.service.js';
 
 // ─── Types ─────────────────────────────────────────────────────────────
 
@@ -210,11 +209,11 @@ export async function updateRichMenu(
 ) {
   const existing = await getRichMenu(prisma, id, tenantId);
 
-  // 守衛：本期僅允許 draft 狀態被修改
+  // 守衛：已發布的 menu 需先 unpublish 才能修改
   if (existing.status !== 'draft') {
     throw new AppError(
-      'Only draft rich menus can be updated; un-publish first',
-      'INVALID_STATUS',
+      '已發布的 Rich Menu 不能直接修改，請先取消發布',
+      'CANNOT_UPDATE_PUBLISHED',
       400,
     );
   }
@@ -250,7 +249,7 @@ export async function deleteRichMenu(
   const existing = await getRichMenu(prisma, id, tenantId);
   if (existing.status !== 'draft') {
     throw new AppError(
-      'Cannot delete a published rich menu; un-publish first',
+      '已發布的 Rich Menu 不能直接刪除，請先取消發布',
       'CANNOT_DELETE_PUBLISHED',
       400,
     );
@@ -278,4 +277,276 @@ export async function duplicateRichMenu(
       status: 'draft',
     },
   });
+}
+
+// ─── Publish / Unpublish ───────────────────────────────────────────────
+
+const LINE_API_BASE = 'https://api.line.me';
+const LINE_DATA_API_BASE = 'https://api-data.line.me';
+const MAX_IMAGE_BYTES = 1024 * 1024; // 1 MB
+
+async function getLineAccessToken(
+  prisma: PrismaClient,
+  channelId: string,
+  tenantId: string,
+): Promise<string> {
+  const channel = await prisma.channel.findFirst({
+    where: { id: channelId, tenantId, channelType: 'LINE' },
+  });
+  if (!channel) {
+    throw new AppError('LINE channel not found', 'NOT_FOUND', 404);
+  }
+  const credentials = decryptCredentials(channel.credentialsEncrypted);
+  const accessToken = credentials.channelAccessToken as string | undefined;
+  if (!accessToken) {
+    throw new AppError(
+      '此 LINE 頻道缺少 channelAccessToken，請先到頻道設定填入',
+      'MISSING_ACCESS_TOKEN',
+      400,
+    );
+  }
+  return accessToken;
+}
+
+interface FetchedImage {
+  buffer: Buffer;
+  contentType: 'image/jpeg' | 'image/png';
+}
+
+async function fetchAndValidateImage(
+  imageUrl: string,
+  size: { width: number; height: number },
+): Promise<FetchedImage> {
+  let response: Response;
+  try {
+    response = await fetch(imageUrl);
+  } catch {
+    throw new AppError(`無法取得背景圖：${imageUrl}`, 'IMAGE_FETCH_FAILED', 400);
+  }
+  if (!response.ok) {
+    throw new AppError(
+      `背景圖回應 ${response.status}：${imageUrl}`,
+      'IMAGE_FETCH_FAILED',
+      400,
+    );
+  }
+
+  const contentTypeHeader = (response.headers.get('content-type') ?? '').toLowerCase();
+  let contentType: 'image/jpeg' | 'image/png';
+  if (contentTypeHeader.includes('image/jpeg') || contentTypeHeader.includes('image/jpg')) {
+    contentType = 'image/jpeg';
+  } else if (contentTypeHeader.includes('image/png')) {
+    contentType = 'image/png';
+  } else {
+    throw new AppError(
+      `背景圖格式必須是 JPEG 或 PNG（實際：${contentTypeHeader || 'unknown'}）`,
+      'IMAGE_INVALID_TYPE',
+      400,
+    );
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+  if (buffer.byteLength > MAX_IMAGE_BYTES) {
+    throw new AppError(
+      `背景圖大小 ${(buffer.byteLength / 1024).toFixed(0)}KB 超過 LINE 限制 1MB`,
+      'IMAGE_TOO_LARGE',
+      400,
+    );
+  }
+  // 註：尺寸（寬高 pixel）由 LINE API 拒絕回報，本地不解析 PNG/JPEG header；
+  // size 欄位已在 create/update 時驗過版型合法，這裡只擋大小與 MIME。
+  void size;
+
+  return { buffer, contentType };
+}
+
+/**
+ * 把現行所有 selected=true 的 published rich menu 取消 default。
+ * LINE 端的「全體 default richmenu」只能有一個；新 publish selected=true
+ * 時要先讓出位置，避免 set default 時與舊的衝突。
+ */
+async function unsetCurrentDefault(
+  prisma: PrismaClient,
+  tenantId: string,
+  channelId: string,
+  accessToken: string,
+  excludeId: string,
+): Promise<void> {
+  const others = await prisma.richMenu.findMany({
+    where: {
+      tenantId,
+      channelId,
+      status: 'published',
+      selected: true,
+      NOT: { id: excludeId },
+      lineRichMenuId: { not: null },
+    },
+  });
+  if (others.length === 0) return;
+
+  // LINE 沒有 per-richmenu 取消 default 的 API；直接呼叫 DELETE all default
+  try {
+    await fetch(`${LINE_API_BASE}/v2/bot/user/all/richmenu`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+  } catch (err) {
+    logger.warn(`[RichMenu] unset default failed: ${(err as Error).message}`);
+  }
+
+  await prisma.richMenu.updateMany({
+    where: { id: { in: others.map((o) => o.id) } },
+    data: { selected: false },
+  });
+}
+
+export async function publishRichMenu(
+  prisma: PrismaClient,
+  id: string,
+  tenantId: string,
+) {
+  const menu = await getRichMenu(prisma, id, tenantId);
+  if (menu.status === 'published') {
+    throw new AppError('此 Rich Menu 已發布', 'ALREADY_PUBLISHED', 400);
+  }
+
+  const accessToken = await getLineAccessToken(prisma, menu.channelId, tenantId);
+  const size = menu.size as unknown as { width: number; height: number };
+  const image = await fetchAndValidateImage(menu.imageUrl, size);
+
+  // 1. 建立 richmenu
+  const createResp = await fetch(`${LINE_API_BASE}/v2/bot/richmenu`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      size,
+      selected: menu.selected,
+      name: menu.name,
+      chatBarText: menu.chatBarText,
+      areas: menu.areas,
+    }),
+  });
+  if (!createResp.ok) {
+    const body = await createResp.text();
+    await prisma.richMenu.update({ where: { id }, data: { status: 'error' } });
+    throw new AppError(
+      `LINE 建立 Rich Menu 失敗 (${createResp.status}): ${body}`,
+      'LINE_API_ERROR',
+      400,
+    );
+  }
+  const { richMenuId } = (await createResp.json()) as { richMenuId: string };
+
+  // 2. 上傳背景圖
+  const uploadResp = await fetch(
+    `${LINE_DATA_API_BASE}/v2/bot/richmenu/${richMenuId}/content`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': image.contentType,
+      },
+      body: image.buffer,
+    },
+  );
+  if (!uploadResp.ok) {
+    const body = await uploadResp.text();
+    // 回滾：刪掉剛建的 richmenu，避免殘留
+    await fetch(`${LINE_API_BASE}/v2/bot/richmenu/${richMenuId}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${accessToken}` },
+    }).catch(() => {});
+    await prisma.richMenu.update({ where: { id }, data: { status: 'error' } });
+    throw new AppError(
+      `LINE 上傳背景圖失敗 (${uploadResp.status}): ${body}`,
+      'LINE_API_ERROR',
+      400,
+    );
+  }
+
+  // 3. 設為 default（若 selected）
+  if (menu.selected) {
+    await unsetCurrentDefault(prisma, tenantId, menu.channelId, accessToken, id);
+
+    const defaultResp = await fetch(
+      `${LINE_API_BASE}/v2/bot/user/all/richmenu/${richMenuId}`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${accessToken}` },
+      },
+    );
+    if (!defaultResp.ok) {
+      const body = await defaultResp.text();
+      logger.warn(`[RichMenu] set default failed: ${defaultResp.status} ${body}`);
+      // 不算致命 — richmenu 已建好，使用者可從 LINE OA 後台手動設 default
+    }
+  }
+
+  const updated = await prisma.richMenu.update({
+    where: { id },
+    data: {
+      status: 'published',
+      lineRichMenuId: richMenuId,
+      publishedAt: new Date(),
+    },
+  });
+  logger.info(`[RichMenu] published id=${id} lineRichMenuId=${richMenuId}`);
+  return updated;
+}
+
+export async function unpublishRichMenu(
+  prisma: PrismaClient,
+  id: string,
+  tenantId: string,
+) {
+  const menu = await getRichMenu(prisma, id, tenantId);
+  if (menu.status !== 'published' && menu.status !== 'error') {
+    throw new AppError('此 Rich Menu 尚未發布', 'NOT_PUBLISHED', 400);
+  }
+
+  const accessToken = await getLineAccessToken(prisma, menu.channelId, tenantId);
+
+  if (menu.lineRichMenuId) {
+    // 若是 default，先 unset default（避免 LINE 端孤兒指向）
+    if (menu.selected) {
+      await fetch(`${LINE_API_BASE}/v2/bot/user/all/richmenu`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${accessToken}` },
+      }).catch((err) => {
+        logger.warn(`[RichMenu] unset default failed during unpublish: ${(err as Error).message}`);
+      });
+    }
+
+    const deleteResp = await fetch(
+      `${LINE_API_BASE}/v2/bot/richmenu/${menu.lineRichMenuId}`,
+      {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${accessToken}` },
+      },
+    );
+    // 404 視為已不存在，可繼續清本地狀態
+    if (!deleteResp.ok && deleteResp.status !== 404) {
+      const body = await deleteResp.text();
+      throw new AppError(
+        `LINE 刪除 Rich Menu 失敗 (${deleteResp.status}): ${body}`,
+        'LINE_API_ERROR',
+        400,
+      );
+    }
+  }
+
+  const updated = await prisma.richMenu.update({
+    where: { id },
+    data: {
+      status: 'draft',
+      lineRichMenuId: null,
+      publishedAt: null,
+    },
+  });
+  logger.info(`[RichMenu] unpublished id=${id}`);
+  return updated;
 }

--- a/apps/api/src/modules/notification/notification.worker.ts
+++ b/apps/api/src/modules/notification/notification.worker.ts
@@ -11,9 +11,17 @@ import { eventBus } from '../../events/event-bus.js';
 import type { AppEvent } from '../../events/event-bus.js';
 import { logger } from '@open333crm/core';
 
-const notificationQueue = new Queue('notification', {
-  connection: { url: process.env.REDIS_URL! },
-});
+// Lazy init：避免在 dotenv 載入前讀到 undefined REDIS_URL，
+// ioredis fallback default 6379 會噴一堆 ECONNREFUSED 噪音
+let _notificationQueue: Queue | null = null;
+function notificationQueue(): Queue {
+  if (!_notificationQueue) {
+    _notificationQueue = new Queue('notification', {
+      connection: { url: process.env.REDIS_URL! },
+    });
+  }
+  return _notificationQueue;
+}
 
 async function getSupervisorAndAdminIds(
   prisma: PrismaClient,
@@ -42,7 +50,7 @@ export function setupNotificationWorker(prisma: PrismaClient) {
 
       if (!assigneeId) return;
 
-      await notificationQueue.add('notification:dispatch', {
+      await notificationQueue().add('notification:dispatch', {
         tenantId: event.tenantId,
         agentId: assigneeId,
         type: 'case_assigned',
@@ -68,7 +76,7 @@ export function setupNotificationWorker(prisma: PrismaClient) {
       const supervisorIds = await getSupervisorAndAdminIds(prisma, event.tenantId);
 
       for (const agentId of supervisorIds) {
-        await notificationQueue.add('notification:dispatch', {
+        await notificationQueue().add('notification:dispatch', {
           tenantId: event.tenantId,
           agentId,
           type: 'case_escalated',
@@ -95,7 +103,7 @@ export function setupNotificationWorker(prisma: PrismaClient) {
 
       if (!assigneeId) return;
 
-      await notificationQueue.add('notification:dispatch', {
+      await notificationQueue().add('notification:dispatch', {
         tenantId: event.tenantId,
         agentId: assigneeId,
         type: 'sla_warning',
@@ -129,7 +137,7 @@ export function setupNotificationWorker(prisma: PrismaClient) {
       }
 
       for (const agentId of notifyIds) {
-        await notificationQueue.add('notification:dispatch', {
+        await notificationQueue().add('notification:dispatch', {
           tenantId: event.tenantId,
           agentId,
           type: 'sla_breached',
@@ -172,7 +180,7 @@ export function setupNotificationWorker(prisma: PrismaClient) {
 
       if (conversation.assignedToId) {
         // Assigned → notify the assigned agent only
-        await notificationQueue.add('notification:dispatch', {
+        await notificationQueue().add('notification:dispatch', {
           ...notifPayload,
           agentId: conversation.assignedToId,
         }).catch((err) => logger.error('[NotificationWorker] Failed to enqueue message.received', err));
@@ -180,7 +188,7 @@ export function setupNotificationWorker(prisma: PrismaClient) {
         // Unassigned → notify all ADMIN and SUPERVISOR agents
         const adminAndSupervisorIds = await getSupervisorAndAdminIds(prisma, event.tenantId);
         for (const agentId of adminAndSupervisorIds) {
-          await notificationQueue.add('notification:dispatch', {
+          await notificationQueue().add('notification:dispatch', {
             ...notifPayload,
             agentId,
           }).catch((err) => logger.error('[NotificationWorker] Failed to enqueue message.received (unassigned)', err));
@@ -202,7 +210,7 @@ export function setupNotificationWorker(prisma: PrismaClient) {
 
       if (!assignedToId || !conversationId) return;
 
-      await notificationQueue.add('notification:dispatch', {
+      await notificationQueue().add('notification:dispatch', {
         tenantId: event.tenantId,
         agentId: assignedToId,
         type: 'new_message',

--- a/apps/api/src/modules/webhook/webhook.service.ts
+++ b/apps/api/src/modules/webhook/webhook.service.ts
@@ -6,6 +6,7 @@ import { eventBus } from '../../events/event-bus.js';
 import type { ParsedWebhookMessage } from '@open333crm/channel-plugins';
 import { trackBroadcastReply } from '../marketing/broadcast.tracking.js';
 import { recordCsatScore } from '../csat/csat.service.js';
+import { recordKbFeedback } from '../knowledge/kb-feedback.service.js';
 import { getOutsideHoursMessage } from '../settings/office-hours.service.js';
 import { deliverToChannel } from '../conversation/conversation.service.js';
 import { handleWebhookFlowTrigger } from '../canvas/canvas.webhook.js';
@@ -378,6 +379,26 @@ export async function processInboundMessage(
       await recordCsatScore(prisma, io, csatCaseId, score);
       return; // Don't publish message.received to avoid triggering automations
     }
+  }
+
+  // 5b. Intercept KB feedback postback：kb_feedback:bad|good:{articleId|none}:{messageId}
+  const fbMatch = postbackData.match(/^kb_feedback:(bad|good):([a-f0-9-]+|none):([a-f0-9-]+)$/i);
+  if (fbMatch) {
+    const rating = fbMatch[1] as 'bad' | 'good';
+    const articleId = fbMatch[2];
+    const fbMessageId = fbMatch[3];
+    try {
+      await recordKbFeedback(prisma, tenantId, {
+        rating,
+        articleId,
+        messageId: fbMessageId,
+        contactId: contactId ?? undefined,
+      });
+      await deliverToChannel(prisma, conversation.id, '感謝您的回報，我們會持續改善 🙏');
+    } catch (err) {
+      logger.error('[Webhook] KB feedback handling failed:', err);
+    }
+    return; // 不發 message.received，不觸發 automation（同 CSAT）
   }
 
   // 6. Track broadcast reply (non-blocking)

--- a/apps/api/src/modules/webhook/webhook.service.ts
+++ b/apps/api/src/modules/webhook/webhook.service.ts
@@ -382,7 +382,10 @@ export async function processInboundMessage(
   }
 
   // 5b. Intercept KB feedback postback：kb_feedback:bad|good:{articleId|none}:{messageId}
-  const fbMatch = postbackData.match(/^kb_feedback:(bad|good):([a-f0-9-]+|none):([a-f0-9-]+)$/i);
+  // 同時比對 postbackData 與 textContent（仿 CSAT）— LINE 走 postback，
+  // 但 FB/WEBCHAT 點 quick reply 可能以文字回傳。
+  const fbPattern = /^kb_feedback:(bad|good):([a-f0-9-]+|none):([a-f0-9-]+)$/i;
+  const fbMatch = postbackData.match(fbPattern) || textContent.match(fbPattern);
   if (fbMatch) {
     const rating = fbMatch[1] as 'bad' | 'good';
     const articleId = fbMatch[2];

--- a/apps/web/src/app/dashboard/knowledge/page.tsx
+++ b/apps/web/src/app/dashboard/knowledge/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import React, { useState, useCallback } from 'react';
-import { Plus, Upload, Search, Loader2, Brain } from 'lucide-react';
+import { Plus, Upload, Search, Loader2, Brain, ThumbsDown, Check, Pencil } from 'lucide-react';
 import { useKnowledge, useCategories } from '@/hooks/useKnowledge';
+import { useKbFeedbackList, resolveKbFeedback } from '@/hooks/useKbFeedback';
 import { ArticleList } from '@/components/knowledge/ArticleList';
 import { ArticleFormDialog } from '@/components/knowledge/ArticleFormDialog';
 import { ImportDialog } from '@/components/knowledge/ImportDialog';
@@ -35,7 +36,29 @@ export default function KnowledgePage() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingArticle, setEditingArticle] = useState<any>(null);
   const [importOpen, setImportOpen] = useState(false);
-  const [pageTab, setPageTab] = useState<'articles' | 'search' | 'embedding' | 'chat'>('articles');
+  const [pageTab, setPageTab] = useState<'articles' | 'search' | 'feedback' | 'embedding' | 'chat'>('articles');
+
+  // KB 回報（調教）
+  const { feedback, isLoading: feedbackLoading, mutate: mutateFeedback } = useKbFeedbackList({ status: 'open' });
+
+  const handleResolveFeedback = useCallback(async (id: string) => {
+    try {
+      await resolveKbFeedback(id);
+      mutateFeedback();
+    } catch (err: any) {
+      alert(err.response?.data?.error?.message || '操作失敗');
+    }
+  }, [mutateFeedback]);
+
+  const handleEditFromFeedback = useCallback(async (articleId: string) => {
+    try {
+      const res = await api.get(`/knowledge/${articleId}`);
+      setEditingArticle(res.data.data);
+      setDialogOpen(true);
+    } catch {
+      alert('找不到此文章，可能已被刪除');
+    }
+  }, []);
 
   // Semantic search state
   const [searchQuery, setSearchQuery] = useState('');
@@ -113,7 +136,8 @@ export default function KnowledgePage() {
     setDialogOpen(false);
     setEditingArticle(null);
     mutate();
-  }, [mutate]);
+    mutateFeedback();
+  }, [mutate, mutateFeedback]);
 
   const handleNewArticle = useCallback(() => {
     setEditingArticle(null);
@@ -147,10 +171,18 @@ export default function KnowledgePage() {
 
       {/* Top-level page tabs: articles vs semantic search */}
       <div className="border-b px-6 pt-2">
-        <Tabs value={pageTab} onValueChange={(v) => setPageTab(v as 'articles' | 'search' | 'embedding' | 'chat')}>
+        <Tabs value={pageTab} onValueChange={(v) => setPageTab(v as 'articles' | 'search' | 'feedback' | 'embedding' | 'chat')}>
           <TabsList>
             <TabsTrigger value="articles">文章管理</TabsTrigger>
             <TabsTrigger value="search">語義搜尋</TabsTrigger>
+            <TabsTrigger value="feedback">
+              回報調教
+              {feedback.length > 0 && (
+                <span className="ml-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white">
+                  {feedback.length}
+                </span>
+              )}
+            </TabsTrigger>
             <TabsTrigger value="embedding">Embedding 設定</TabsTrigger>
             <TabsTrigger value="chat">Chat & Prompt</TabsTrigger>
           </TabsList>
@@ -298,6 +330,81 @@ export default function KnowledgePage() {
                 <p className="text-center text-sm text-muted-foreground py-8">
                   輸入關鍵字進行語義搜尋，系統會根據向量相似度找到最相關的知識庫文章
                 </p>
+              )}
+            </div>
+          </TabsContent>
+
+          {/* ── 回報調教 Tab ──────────────────────────────────── */}
+          <TabsContent value="feedback" className="flex h-[calc(100vh-130px)] flex-col">
+            <div className="border-b py-3 shrink-0">
+              <p className="text-sm text-muted-foreground">
+                使用者在 LINE 點「👎 沒幫到我」的回報。點「編輯文章」修正知識庫內容（存檔後自動重新嵌入），處理完點「標為已處理」。
+              </p>
+            </div>
+            <div className="flex-1 min-h-0 overflow-auto py-2">
+              {feedbackLoading ? (
+                <div className="flex items-center justify-center py-12">
+                  <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                </div>
+              ) : feedback.length === 0 ? (
+                <p className="py-12 text-center text-sm text-muted-foreground">
+                  目前沒有待處理的回報 🎉
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  {feedback.map((f) => (
+                    <div key={f.id} className="rounded-lg border p-4">
+                      <div className="flex items-start gap-2">
+                        <ThumbsDown className="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2">
+                            <span className="text-xs text-muted-foreground">
+                              {new Date(f.createdAt).toLocaleString('zh-TW')}
+                            </span>
+                            {f.confidence != null && (
+                              <Badge variant="outline" className="text-[10px]">
+                                相似度 {(f.confidence * 100).toFixed(0)}%
+                              </Badge>
+                            )}
+                          </div>
+                          <div className="mt-1.5 text-sm">
+                            <span className="font-medium text-slate-700">使用者問：</span>
+                            {f.userQuestion || <span className="text-muted-foreground">（無法取得問句）</span>}
+                          </div>
+                          <div className="mt-1 text-sm text-muted-foreground">
+                            <span className="font-medium">Bot 回答：</span>
+                            {f.botReply ? (f.botReply.length > 150 ? f.botReply.slice(0, 150) + '…' : f.botReply) : '—'}
+                          </div>
+                          <div className="mt-1.5 text-xs">
+                            <span className="text-muted-foreground">命中文章：</span>
+                            <span className="font-medium">{f.article?.title || f.articleId}</span>
+                            {f.article?.externalDocId && (
+                              <span className="ml-1 text-muted-foreground">(DocID {f.article.externalDocId})</span>
+                            )}
+                          </div>
+                        </div>
+                        <div className="flex shrink-0 flex-col gap-1.5">
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => handleEditFromFeedback(f.articleId)}
+                          >
+                            <Pencil className="mr-1 h-3 w-3" />
+                            編輯文章
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => handleResolveFeedback(f.id)}
+                          >
+                            <Check className="mr-1 h-3 w-3" />
+                            標為已處理
+                          </Button>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
               )}
             </div>
           </TabsContent>

--- a/apps/web/src/app/dashboard/line/keyword-replies/page.tsx
+++ b/apps/web/src/app/dashboard/line/keyword-replies/page.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+/**
+ * LINE 關鍵字回覆管理頁
+ *
+ * 用戶傳訊息含關鍵字時 → 自動回對應素材。
+ * 底層走 automation rules (keyword.matched + send_material)。
+ */
+
+import React, { useState } from 'react';
+import { Plus, Edit, Trash2, Power, PowerOff, Info } from 'lucide-react';
+import { Topbar } from '@/components/layout/Topbar';
+import { Button } from '@/components/ui/button';
+import { LineModuleTabs } from '@/components/line/LineModuleTabs';
+import { KeywordReplyEditDialog } from '@/components/line/keyword-reply/KeywordReplyEditDialog';
+import { useMaterials } from '@/hooks/useMaterials';
+import {
+  useKeywordReplies,
+  createKeywordReply,
+  updateKeywordReply,
+  deleteKeywordReply,
+  toggleKeywordReply,
+  type KeywordReply,
+} from '@/hooks/useKeywordReplies';
+
+export default function KeywordRepliesPage() {
+  const { replies, isLoading, mutate } = useKeywordReplies();
+  const { materials } = useMaterials({ channelType: 'line', isActive: true, limit: 200 });
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<KeywordReply | null>(null);
+
+  const materialMap = new Map(materials.map((m) => [m.id, m]));
+
+  const handleOpenCreate = () => { setEditing(null); setDialogOpen(true); };
+  const handleOpenEdit = (r: KeywordReply) => { setEditing(r); setDialogOpen(true); };
+
+  const handleSave = async (input: Parameters<typeof createKeywordReply>[0]) => {
+    if (editing) {
+      await updateKeywordReply(editing.id, input);
+    } else {
+      await createKeywordReply(input);
+    }
+    await mutate();
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('確定刪除這條關鍵字回覆？')) return;
+    try {
+      await deleteKeywordReply(id);
+      mutate();
+    } catch (err: unknown) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      alert(((err as any)?.response?.data?.error?.message) ?? '刪除失敗');
+    }
+  };
+
+  const handleToggle = async (r: KeywordReply) => {
+    try {
+      await toggleKeywordReply(r.id, !r.isActive);
+      mutate();
+    } catch (err: unknown) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      alert(((err as any)?.response?.data?.error?.message) ?? '更新失敗');
+    }
+  };
+
+  return (
+    <div className="flex h-screen flex-col bg-slate-50">
+      <Topbar title="LINE 管理" />
+      <LineModuleTabs active="keyword-replies" />
+
+      <main className="flex-1 overflow-y-auto p-6">
+        <div className="mx-auto max-w-6xl space-y-5">
+          <header className="flex items-start justify-between">
+            <div>
+              <h1 className="text-2xl font-bold tracking-tight">關鍵字回覆</h1>
+              <p className="mt-1 text-sm text-slate-500">
+                用戶在 LINE 傳訊息中出現指定關鍵字時，系統自動回覆對應素材（圖片 / Flex / 輪播 / 圖文等）。
+              </p>
+            </div>
+            <Button onClick={handleOpenCreate}>
+              <Plus className="mr-1 h-4 w-4" />
+              建立關鍵字回覆
+            </Button>
+          </header>
+
+          {/* 說明 */}
+          <section className="rounded-lg border border-slate-200 bg-white p-4">
+            <div className="flex items-center gap-1.5 text-sm font-semibold">
+              <Info className="h-4 w-4 text-blue-500" />
+              怎麼用？
+            </div>
+            <ol className="ml-1 mt-2 list-decimal space-y-1 pl-4 text-sm text-slate-600">
+              <li>先到「<a href="/dashboard/marketing/materials" className="text-blue-600 underline">行銷 → 素材庫</a>」建立你要回覆的內容（純文字、圖片、Flex、輪播都行）</li>
+              <li>回來這頁按「建立關鍵字回覆」，輸入規則名稱、關鍵字（一個或多個）、選素材</li>
+              <li>用戶在 LINE 傳訊息含關鍵字 → bot 自動回覆對應素材</li>
+            </ol>
+            <div className="mt-2 rounded border border-amber-200 bg-amber-50 px-3 py-1.5 text-xs text-amber-800">
+              ⚙️ 這條規則跑在 bot 模式（BOT_HANDLED 狀態的對話）才會觸發。已被客服接管的對話不會自動回。每個聯絡人對同一條規則 1 小時最多觸發 3 次（防轟炸）。
+            </div>
+          </section>
+
+          {isLoading && (
+            <div className="py-12 text-center text-sm text-slate-500">載入中…</div>
+          )}
+
+          {!isLoading && replies.length === 0 && (
+            <div className="rounded-lg border border-dashed border-slate-300 bg-white py-16 text-center">
+              <div className="text-sm text-slate-500">尚未建立任何關鍵字回覆</div>
+              <Button className="mt-3" onClick={handleOpenCreate}>
+                <Plus className="mr-1 h-4 w-4" />
+                建立第一條
+              </Button>
+            </div>
+          )}
+
+          {!isLoading && replies.length > 0 && (
+            <div className="overflow-hidden rounded-lg border border-slate-200 bg-white">
+              <table className="w-full text-sm">
+                <thead className="bg-slate-50 text-xs text-slate-500">
+                  <tr>
+                    <th className="px-4 py-2 text-left font-medium">狀態</th>
+                    <th className="px-4 py-2 text-left font-medium">規則名稱</th>
+                    <th className="px-4 py-2 text-left font-medium">關鍵字</th>
+                    <th className="px-4 py-2 text-left font-medium">回覆素材</th>
+                    <th className="px-4 py-2 text-right font-medium">動作</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100">
+                  {replies.map((r) => {
+                    const mat = materialMap.get(r.materialId);
+                    return (
+                      <tr key={r.id} className={r.isActive ? '' : 'opacity-50'}>
+                        <td className="px-4 py-3">
+                          <button
+                            type="button"
+                            onClick={() => handleToggle(r)}
+                            title={r.isActive ? '已啟用（點擊停用）' : '已停用（點擊啟用）'}
+                            className={
+                              r.isActive
+                                ? 'inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs text-green-700'
+                                : 'inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-500'
+                            }
+                          >
+                            {r.isActive ? <Power className="h-3 w-3" /> : <PowerOff className="h-3 w-3" />}
+                            {r.isActive ? '啟用' : '停用'}
+                          </button>
+                        </td>
+                        <td className="px-4 py-3 font-medium">{r.name}</td>
+                        <td className="px-4 py-3">
+                          <div className="flex flex-wrap gap-1">
+                            {r.keywords.slice(0, 5).map((k, idx) => (
+                              <span
+                                key={idx}
+                                className="inline-flex rounded-full border border-blue-200 bg-blue-50 px-2 py-0.5 text-[11px] text-blue-900"
+                              >
+                                {k}
+                              </span>
+                            ))}
+                            {r.keywords.length > 5 && (
+                              <span className="text-[11px] text-slate-400">+{r.keywords.length - 5}</span>
+                            )}
+                            {r.keywords.length > 1 && (
+                              <span className="text-[11px] text-slate-400">
+                                ({r.matchMode === 'all' ? '全部' : '任一'})
+                              </span>
+                            )}
+                          </div>
+                        </td>
+                        <td className="px-4 py-3">
+                          {mat ? (
+                            <div>
+                              <div className="text-xs font-medium">{mat.name}</div>
+                              <div className="text-[11px] text-slate-500">{mat.contentType}</div>
+                            </div>
+                          ) : (
+                            <span className="text-xs text-red-500">素材已被刪除（id: {r.materialId.slice(0, 8)}…）</span>
+                          )}
+                        </td>
+                        <td className="px-4 py-3 text-right">
+                          <Button variant="ghost" size="sm" onClick={() => handleOpenEdit(r)}>
+                            <Edit className="mr-1 h-3 w-3" />編輯
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-red-600 hover:bg-red-50 hover:text-red-700"
+                            onClick={() => handleDelete(r.id)}
+                          >
+                            <Trash2 className="mr-1 h-3 w-3" />刪除
+                          </Button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </main>
+
+      <KeywordReplyEditDialog
+        open={dialogOpen}
+        reply={editing}
+        onClose={() => setDialogOpen(false)}
+        onSave={handleSave}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/line/quick-replies/page.tsx
+++ b/apps/web/src/app/dashboard/line/quick-replies/page.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+/**
+ * Quick Reply 預設組管理頁
+ *
+ * - LINE quick reply 沒有「全域設定」概念，這裡管理的是「可重用按鈕組」
+ * - 客服在 MessageInput 加 quick reply 時可一鍵套用整組
+ */
+
+import React, { useState } from 'react';
+import { Plus, Edit, Trash2, Info } from 'lucide-react';
+import { Topbar } from '@/components/layout/Topbar';
+import { Button } from '@/components/ui/button';
+import { LineModuleTabs } from '@/components/line/LineModuleTabs';
+import { PresetEditDialog } from '@/components/line/quick-reply/PresetEditDialog';
+import { LinePreview } from '@/components/line/quick-reply/LinePreview';
+import {
+  useQuickReplyPresets,
+  createQuickReplyPreset,
+  updateQuickReplyPreset,
+  deleteQuickReplyPreset,
+  type QuickReplyPreset,
+} from '@/hooks/useQuickReplyPresets';
+
+export default function QuickReplyPresetsPage() {
+  const { presets, isLoading, mutate } = useQuickReplyPresets();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<QuickReplyPreset | null>(null);
+
+  const handleOpenCreate = () => {
+    setEditing(null);
+    setDialogOpen(true);
+  };
+
+  const handleOpenEdit = (preset: QuickReplyPreset) => {
+    setEditing(preset);
+    setDialogOpen(true);
+  };
+
+  const handleSave = async (data: { name: string; items: QuickReplyPreset['items'] }) => {
+    if (editing) {
+      await updateQuickReplyPreset(editing.id, data);
+    } else {
+      await createQuickReplyPreset(data);
+    }
+    await mutate();
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('確定刪除這個預設組？')) return;
+    try {
+      await deleteQuickReplyPreset(id);
+      mutate();
+    } catch (err: unknown) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      alert(((err as any)?.response?.data?.error?.message) ?? '刪除失敗');
+    }
+  };
+
+  return (
+    <div className="flex h-screen flex-col bg-slate-50">
+      <Topbar title="LINE 管理" />
+      <LineModuleTabs active="quick-replies" />
+
+      <main className="flex-1 overflow-y-auto p-6">
+        <div className="mx-auto max-w-6xl space-y-5">
+          <header className="flex items-start justify-between">
+            <div>
+              <h1 className="text-2xl font-bold tracking-tight">Quick Reply 預設組</h1>
+              <p className="mt-1 text-sm text-slate-500">
+                LINE 的「快速回覆」是出現在訊息底部的一排泡泡按鈕，用戶點一下就送出對應訊息給客服。
+              </p>
+            </div>
+            <Button onClick={handleOpenCreate}>
+              <Plus className="mr-1 h-4 w-4" />
+              建立預設組
+            </Button>
+          </header>
+
+          {/* 是什麼 / 為何要建預設組 — 給第一次看到的人一個入口 */}
+          <section className="grid grid-cols-1 gap-4 rounded-lg border border-slate-200 bg-white p-4 md:grid-cols-[1fr,320px]">
+            <div className="space-y-2">
+              <div className="flex items-center gap-1.5 text-sm font-semibold">
+                <Info className="h-4 w-4 text-blue-500" />
+                這頁可以做什麼？
+              </div>
+              <ul className="ml-1 list-disc space-y-1 pl-4 text-sm text-slate-600">
+                <li>把常用的按鈕組存起來（例：「同意 / 不同意」、「滿意度 1～5 分」、「想了解 A / B / C 方案」）</li>
+                <li>客服在聊天室回訊息時，點「閃電」icon → 「套用預設組」即可一次帶入整組按鈕，不用每次手刻</li>
+                <li>每則 LINE 訊息最多 13 個按鈕（LINE 官方限制）</li>
+              </ul>
+              <div className="rounded border border-amber-200 bg-amber-50 px-3 py-1.5 text-xs text-amber-800">
+                💡 預設組只是「按鈕模板」，實際送出去時你還是需要打一句訊息內容（例如「請問您是否同意？」），按鈕會自動附在訊息底下
+              </div>
+            </div>
+            <div className="space-y-1.5">
+              <div className="text-xs font-semibold uppercase tracking-wide text-slate-600">範例</div>
+              <LinePreview
+                message="請問您對本次服務的滿意度？"
+                items={[
+                  { label: '😍 非常滿意', text: '5 分：非常滿意' },
+                  { label: '🙂 還可以', text: '3 分：普通' },
+                  { label: '😕 不滿意', text: '1 分：不滿意' },
+                ]}
+              />
+            </div>
+          </section>
+
+          {isLoading && (
+            <div className="py-12 text-center text-sm text-slate-500">載入中…</div>
+          )}
+
+          {!isLoading && presets.length === 0 && (
+            <div className="rounded-lg border border-dashed border-slate-300 bg-white py-16 text-center">
+              <div className="text-sm text-slate-500">尚未建立任何預設組</div>
+              <Button className="mt-3" onClick={handleOpenCreate}>
+                <Plus className="mr-1 h-4 w-4" />
+                建立第一個預設組
+              </Button>
+            </div>
+          )}
+
+          {!isLoading && presets.length > 0 && (
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {presets.map((p) => (
+                <PresetCard
+                  key={p.id}
+                  preset={p}
+                  onEdit={() => handleOpenEdit(p)}
+                  onDelete={() => handleDelete(p.id)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+
+      <PresetEditDialog
+        open={dialogOpen}
+        preset={editing}
+        onClose={() => setDialogOpen(false)}
+        onSave={handleSave}
+      />
+    </div>
+  );
+}
+
+function PresetCard({
+  preset,
+  onEdit,
+  onDelete,
+}: {
+  preset: QuickReplyPreset;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
+      <div className="space-y-3 p-4">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <div className="truncate font-semibold text-slate-900">{preset.name}</div>
+            <div className="mt-0.5 text-xs text-slate-500">
+              {preset.items.length} 個按鈕
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-1">
+          {preset.items.slice(0, 6).map((it, idx) => (
+            <span
+              key={idx}
+              className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11px]"
+            >
+              {it.label}
+            </span>
+          ))}
+          {preset.items.length > 6 && (
+            <span className="text-[11px] text-slate-400">+{preset.items.length - 6}</span>
+          )}
+        </div>
+
+        <div className="text-[11px] text-slate-400">
+          {new Date(preset.updatedAt).toISOString().slice(0, 10)}
+        </div>
+
+        <div className="flex items-center justify-end gap-1">
+          <Button variant="ghost" size="sm" onClick={onEdit}>
+            <Edit className="mr-1 h-3 w-3" />
+            編輯
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-red-600 hover:bg-red-50 hover:text-red-700"
+            onClick={onDelete}
+          >
+            <Trash2 className="mr-1 h-3 w-3" />
+            刪除
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/line/rich-menus/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/line/rich-menus/[id]/page.tsx
@@ -2,12 +2,24 @@
 
 import React, { useEffect, useState } from 'react';
 import { useRouter, useParams } from 'next/navigation';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Send, Undo2 } from 'lucide-react';
 import { Topbar } from '@/components/layout/Topbar';
 import { LineModuleTabs } from '@/components/line/LineModuleTabs';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import { RichMenuEditor, type RichMenuDraft } from '@/components/line/rich-menu/RichMenuEditor';
-import { useRichMenu, updateRichMenu } from '@/hooks/useRichMenus';
+import {
+  useRichMenu,
+  updateRichMenu,
+  publishRichMenu,
+  unpublishRichMenu,
+} from '@/hooks/useRichMenus';
+
+const STATUS_LABELS: Record<string, { label: string; color: string }> = {
+  draft: { label: '草稿', color: '#94a3b8' },
+  published: { label: '已發布', color: '#22c55e' },
+  error: { label: '發布失敗', color: '#ef4444' },
+};
 
 export default function EditRichMenuPage() {
   const router = useRouter();
@@ -17,7 +29,12 @@ export default function EditRichMenuPage() {
   const { richMenu, isLoading, mutate } = useRichMenu(id);
   const [draft, setDraft] = useState<RichMenuDraft | null>(null);
   const [saving, setSaving] = useState(false);
+  const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isPublished = richMenu?.status === 'published';
+  const statusInfo = richMenu
+    ? STATUS_LABELS[richMenu.status] || { label: richMenu.status, color: '#6b7280' }
+    : null;
 
   useEffect(() => {
     if (!richMenu) return;
@@ -54,6 +71,36 @@ export default function EditRichMenuPage() {
     }
   };
 
+  const handlePublish = async () => {
+    if (!confirm('確定發布到 LINE？發布後將無法直接編輯，需先取消發布。')) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await publishRichMenu(id);
+      await mutate();
+    } catch (err: unknown) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      setError(((err as any)?.response?.data?.error?.message) ?? '發布失敗');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleUnpublish = async () => {
+    if (!confirm('確定取消發布？將從 LINE 移除此 Rich Menu。')) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await unpublishRichMenu(id);
+      await mutate();
+    } catch (err: unknown) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      setError(((err as any)?.response?.data?.error?.message) ?? '取消發布失敗');
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const backToList = () => {
     const cid = richMenu?.channelId ?? draft?.channelId;
     router.push(cid ? `/dashboard/line/rich-menus?channelId=${cid}` : '/dashboard/line/rich-menus');
@@ -66,10 +113,21 @@ export default function EditRichMenuPage() {
 
       <main className="flex-1 overflow-y-auto p-6">
         <div className="mx-auto max-w-6xl space-y-5">
-          <Button variant="ghost" size="sm" onClick={backToList}>
-            <ArrowLeft className="mr-1 h-4 w-4" />
-            回到列表
-          </Button>
+          <div className="flex items-center justify-between">
+            <Button variant="ghost" size="sm" onClick={backToList}>
+              <ArrowLeft className="mr-1 h-4 w-4" />
+              回到列表
+            </Button>
+            {statusInfo && (
+              <Badge color={statusInfo.color}>{statusInfo.label}</Badge>
+            )}
+          </div>
+
+          {isPublished && (
+            <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+              此 Rich Menu 已發布到 LINE，不能直接修改。請先「取消發布」後再編輯。
+            </div>
+          )}
 
           {isLoading && <div className="py-12 text-center text-sm text-slate-500">載入中…</div>}
 
@@ -87,12 +145,27 @@ export default function EditRichMenuPage() {
 
           {draft && (
             <div className="space-y-4">
-              <RichMenuEditor draft={draft} onChange={setDraft} />
+              <fieldset disabled={isPublished} className={isPublished ? 'opacity-60' : ''}>
+                <RichMenuEditor draft={draft} onChange={setDraft} />
+              </fieldset>
               <div className="sticky bottom-0 -mx-6 flex justify-end gap-2 border-t bg-white px-6 py-3">
                 <Button variant="outline" onClick={backToList}>取消</Button>
-                <Button onClick={handleSave} disabled={saving}>
-                  {saving ? '儲存中…' : '儲存草稿'}
-                </Button>
+                {!isPublished && (
+                  <Button variant="outline" onClick={handleSave} disabled={saving || busy}>
+                    {saving ? '儲存中…' : '儲存草稿'}
+                  </Button>
+                )}
+                {!isPublished ? (
+                  <Button onClick={handlePublish} disabled={saving || busy}>
+                    <Send className="mr-1 h-4 w-4" />
+                    {busy ? '發布中…' : '發布到 LINE'}
+                  </Button>
+                ) : (
+                  <Button variant="outline" onClick={handleUnpublish} disabled={busy}>
+                    <Undo2 className="mr-1 h-4 w-4" />
+                    {busy ? '取消中…' : '取消發布'}
+                  </Button>
+                )}
               </div>
             </div>
           )}

--- a/apps/web/src/app/dashboard/line/rich-menus/page.tsx
+++ b/apps/web/src/app/dashboard/line/rich-menus/page.tsx
@@ -10,7 +10,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { Plus, Copy, Trash2, Edit, MoreHorizontal } from 'lucide-react';
+import { Plus, Copy, Trash2, Edit, MoreHorizontal, Send, Undo2 } from 'lucide-react';
 import { Topbar } from '@/components/layout/Topbar';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -20,6 +20,8 @@ import {
   useRichMenus,
   deleteRichMenu,
   duplicateRichMenu,
+  publishRichMenu,
+  unpublishRichMenu,
   type RichMenu,
 } from '@/hooks/useRichMenus';
 
@@ -77,6 +79,28 @@ export default function RichMenusPage() {
     }
   };
 
+  const handlePublish = async (id: string) => {
+    if (!confirm('確定發布到 LINE？發布後將無法直接編輯，需先取消發布。')) return;
+    try {
+      await publishRichMenu(id);
+      mutate();
+    } catch (err: unknown) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      alert(((err as any)?.response?.data?.error?.message) ?? '發布失敗');
+    }
+  };
+
+  const handleUnpublish = async (id: string) => {
+    if (!confirm('確定取消發布？將從 LINE 移除此 Rich Menu。')) return;
+    try {
+      await unpublishRichMenu(id);
+      mutate();
+    } catch (err: unknown) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      alert(((err as any)?.response?.data?.error?.message) ?? '取消發布失敗');
+    }
+  };
+
   return (
     <div className="flex h-screen flex-col bg-slate-50">
       <Topbar title="LINE 管理" />
@@ -93,7 +117,7 @@ export default function RichMenusPage() {
             <div>
               <h1 className="text-2xl font-bold tracking-tight">Rich Menu</h1>
               <p className="mt-1 text-sm text-slate-500">
-                LINE 聊天視窗底部的固定選單。本期僅支援草稿管理，發布功能後續上線。
+                LINE 聊天視窗底部的固定選單。建立草稿後可直接發布到 LINE。
               </p>
             </div>
             {channelId && (
@@ -138,6 +162,8 @@ export default function RichMenusPage() {
                   onEdit={(id) => router.push(`/dashboard/line/rich-menus/${id}`)}
                   onDuplicate={handleDuplicate}
                   onDelete={handleDelete}
+                  onPublish={handlePublish}
+                  onUnpublish={handleUnpublish}
                 />
               ))}
             </div>
@@ -153,14 +179,20 @@ function RichMenuCard({
   onEdit,
   onDuplicate,
   onDelete,
+  onPublish,
+  onUnpublish,
 }: {
   richMenu: RichMenu;
   onEdit: (id: string) => void;
   onDuplicate: (id: string) => void;
   onDelete: (id: string) => void;
+  onPublish: (id: string) => void;
+  onUnpublish: (id: string) => void;
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const statusInfo = STATUS_LABELS[richMenu.status] || { label: richMenu.status, color: '#6b7280' };
+  const isPublished = richMenu.status === 'published';
+  const isDraft = richMenu.status === 'draft';
 
   return (
     <div className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
@@ -188,7 +220,25 @@ function RichMenuCard({
         </div>
 
         <div className="flex items-center justify-end gap-1 pt-1">
-          <Button variant="ghost" size="sm" onClick={() => onEdit(richMenu.id)}>
+          {isDraft && (
+            <Button variant="default" size="sm" onClick={() => onPublish(richMenu.id)}>
+              <Send className="mr-1 h-3 w-3" />
+              發布
+            </Button>
+          )}
+          {isPublished && (
+            <Button variant="outline" size="sm" onClick={() => onUnpublish(richMenu.id)}>
+              <Undo2 className="mr-1 h-3 w-3" />
+              取消發布
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onEdit(richMenu.id)}
+            disabled={isPublished}
+            title={isPublished ? '已發布需先取消發布才能編輯' : undefined}
+          >
             <Edit className="mr-1 h-3 w-3" />
             編輯
           </Button>
@@ -207,7 +257,9 @@ function RichMenuCard({
                 </button>
                 <button
                   type="button"
-                  className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-red-600 hover:bg-red-50"
+                  className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-red-600 hover:bg-red-50 disabled:opacity-40 disabled:cursor-not-allowed"
+                  disabled={isPublished}
+                  title={isPublished ? '已發布需先取消發布才能刪除' : undefined}
                   onClick={() => { setMenuOpen(false); onDelete(richMenu.id); }}
                 >
                   <Trash2 className="h-3 w-3" />刪除

--- a/apps/web/src/components/inbox/ChatWindow.tsx
+++ b/apps/web/src/components/inbox/ChatWindow.tsx
@@ -50,6 +50,7 @@ export function ChatWindow({ conversation, onShowAiSuggest, showAiSuggest }: Cha
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [templatePickerOpen, setTemplatePickerOpen] = useState(false);
   const [templateText, setTemplateText] = useState<string | null>(null);
+  const [templateQuickReplies, setTemplateQuickReplies] = useState<Array<{ label: string; text?: string }> | null>(null);
   const [closeDialogOpen, setCloseDialogOpen] = useState(false);
   const [closeReason, setCloseReason] = useState('');
   const [closing, setClosing] = useState(false);
@@ -123,12 +124,20 @@ export function ChatWindow({ conversation, onShowAiSuggest, showAiSuggest }: Cha
     if (contentType === 'image' || contentType === 'file') {
       await sendMessage(JSON.stringify({ url: contentData?.url, fileName: contentData?.fileName }), contentType);
     } else {
-      await sendMessage(content);
+      // 純文字訊息：可帶 quickReplies 等額外 content 欄位
+      const extra = contentData?.quickReplies
+        ? { quickReplies: contentData.quickReplies }
+        : undefined;
+      await sendMessage(content, 'text', extra);
     }
   }, [sendMessage]);
 
-  const handleTemplateSelect = (text: string) => {
+  const handleTemplateSelect = (
+    text: string,
+    extra?: { quickReplies?: Array<{ label: string; text?: string }> },
+  ) => {
     setTemplateText(text);
+    setTemplateQuickReplies(extra?.quickReplies ?? null);
   };
 
   // Auto-scroll on new messages
@@ -136,12 +145,19 @@ export function ChatWindow({ conversation, onShowAiSuggest, showAiSuggest }: Cha
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
-  // Clear template text after it's consumed
+  // Apply selected template into MessageInput (text + optional quick replies)
   useEffect(() => {
-    if (templateText !== null) {
-      setTemplateText(null);
+    if (templateText === null) return;
+    const textarea = document.querySelector<HTMLTextAreaElement>(
+      'textarea[data-message-input]',
+    );
+    const setter = textarea && (textarea as unknown as { __setMessage?: (t: string, q?: unknown) => void }).__setMessage;
+    if (setter) {
+      setter(templateText, templateQuickReplies ?? undefined);
     }
-  }, [templateText]);
+    setTemplateText(null);
+    setTemplateQuickReplies(null);
+  }, [templateText, templateQuickReplies]);
 
   if (!conversation) {
     return (

--- a/apps/web/src/components/inbox/MessageInput.tsx
+++ b/apps/web/src/components/inbox/MessageInput.tsx
@@ -1,11 +1,21 @@
 'use client';
 
 import React, { useState, useRef } from 'react';
-import { Send, Paperclip, LayoutTemplate } from 'lucide-react';
+import { Send, Paperclip, LayoutTemplate, Zap, X, Plus, ListChecks } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import api from '@/lib/api';
 import type { ChannelType } from '@open333crm/shared';
 import { CHANNEL_TYPE } from '@open333crm/shared';
+import { useQuickReplyPresets } from '@/hooks/useQuickReplyPresets';
+
+interface QuickReplyItem {
+  label: string;
+  text?: string;
+}
+
+// LINE 規格：最多 13 個 quick reply items；label ≤ 20 字
+const MAX_QUICK_REPLIES = 13;
+const QUICK_REPLY_LABEL_MAX = 20;
 
 interface MessageInputProps {
   onSend: (content: string, contentType?: string, contentData?: Record<string, unknown>) => Promise<void>;
@@ -32,10 +42,25 @@ export function MessageInput({
 }: MessageInputProps) {
   const [message, setMessage] = useState('');
   const [sending, setSending] = useState(false);
+  const [quickReplies, setQuickReplies] = useState<QuickReplyItem[]>([]);
+  const [quickReplyEditorOpen, setQuickReplyEditorOpen] = useState(false);
+  const [draftLabel, setDraftLabel] = useState('');
+  const [draftText, setDraftText] = useState('');
+  const [presetMenuOpen, setPresetMenuOpen] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const isDisabled = disabled || isBotHandled || sending;
+  const supportsQuickReply = channelType === CHANNEL_TYPE.LINE;
+
+  // 只在 LINE channel 載入 presets（避免其他 channel 多餘請求）
+  const { presets } = useQuickReplyPresets();
+
+  const handleApplyPreset = (preset: { items: QuickReplyItem[] }) => {
+    setQuickReplies(preset.items.slice(0, MAX_QUICK_REPLIES));
+    setPresetMenuOpen(false);
+    setQuickReplyEditorOpen(true);
+  };
 
   const handleSend = async () => {
     const trimmed = message.trim();
@@ -43,8 +68,10 @@ export function MessageInput({
 
     setSending(true);
     try {
-      await onSend(trimmed);
+      const contentData = quickReplies.length > 0 ? { quickReplies } : undefined;
+      await onSend(trimmed, 'text', contentData);
       setMessage('');
+      setQuickReplies([]);
       if (textareaRef.current) {
         textareaRef.current.style.height = 'auto';
       }
@@ -53,6 +80,20 @@ export function MessageInput({
     } finally {
       setSending(false);
     }
+  };
+
+  const handleAddQuickReply = () => {
+    const label = draftLabel.trim();
+    if (!label) return;
+    if (quickReplies.length >= MAX_QUICK_REPLIES) return;
+    const text = draftText.trim() || undefined;
+    setQuickReplies([...quickReplies, { label, text }]);
+    setDraftLabel('');
+    setDraftText('');
+  };
+
+  const handleRemoveQuickReply = (idx: number) => {
+    setQuickReplies(quickReplies.filter((_, i) => i !== idx));
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -112,9 +153,13 @@ export function MessageInput({
     }
   };
 
-  // Fill message from template
-  const setMessageFromTemplate = (text: string) => {
+  // Fill message from template；可一併帶入 quick replies
+  const setMessageFromTemplate = (text: string, qrs?: QuickReplyItem[]) => {
     setMessage(text);
+    if (qrs && qrs.length > 0) {
+      setQuickReplies(qrs.slice(0, MAX_QUICK_REPLIES));
+      setQuickReplyEditorOpen(true);
+    }
     // Focus textarea
     setTimeout(() => {
       textareaRef.current?.focus();
@@ -149,6 +194,121 @@ export function MessageInput({
       )}
 
       <div className="p-4">
+        {/* Quick reply chips + editor (LINE only) */}
+        {supportsQuickReply && (quickReplies.length > 0 || quickReplyEditorOpen) && (
+          <div className="mb-2 rounded-md border border-dashed border-slate-300 bg-slate-50 p-2">
+            <div className="mb-1 flex items-center justify-between gap-2">
+              <div className="text-xs font-medium text-slate-600">
+                快速回覆按鈕（{quickReplies.length}/{MAX_QUICK_REPLIES}）
+              </div>
+              <div className="flex items-center gap-1">
+                {presets.length > 0 && (
+                  <div className="relative">
+                    <button
+                      type="button"
+                      className="inline-flex items-center gap-1 rounded border border-slate-300 bg-white px-2 py-0.5 text-xs text-slate-700 hover:bg-slate-50"
+                      onClick={() => setPresetMenuOpen((v) => !v)}
+                    >
+                      <ListChecks className="h-3 w-3" />
+                      套用預設組
+                    </button>
+                    {presetMenuOpen && (
+                      <div className="absolute right-0 top-full z-20 mt-1 max-h-64 w-56 overflow-y-auto rounded-md border border-slate-200 bg-white py-1 shadow-md">
+                        {presets.map((p) => (
+                          <button
+                            key={p.id}
+                            type="button"
+                            className="block w-full px-3 py-1.5 text-left text-xs hover:bg-slate-50"
+                            onClick={() => handleApplyPreset(p)}
+                            title={p.items.map((i) => i.label).join(' / ')}
+                          >
+                            <div className="truncate font-medium">{p.name}</div>
+                            <div className="truncate text-[10px] text-slate-400">
+                              {p.items.length} 個 · {p.items.slice(0, 3).map((i) => i.label).join(' / ')}
+                              {p.items.length > 3 ? ' …' : ''}
+                            </div>
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+                <button
+                  type="button"
+                  className="text-xs text-slate-500 hover:text-slate-700"
+                  onClick={() => setQuickReplyEditorOpen((v) => !v)}
+                >
+                  {quickReplyEditorOpen ? '收合' : '展開'}
+                </button>
+              </div>
+            </div>
+            {quickReplies.length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {quickReplies.map((qr, idx) => (
+                  <span
+                    key={idx}
+                    className="inline-flex items-center gap-1 rounded-full border border-slate-300 bg-white px-2.5 py-1 text-xs"
+                    title={qr.text ? `送出文字：${qr.text}` : `送出文字：${qr.label}`}
+                  >
+                    <span className="font-medium">{qr.label}</span>
+                    {qr.text && qr.text !== qr.label && (
+                      <span className="text-slate-400">→ {qr.text}</span>
+                    )}
+                    <button
+                      type="button"
+                      className="ml-0.5 text-slate-400 hover:text-red-500"
+                      onClick={() => handleRemoveQuickReply(idx)}
+                      title="移除"
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+            {quickReplyEditorOpen && quickReplies.length < MAX_QUICK_REPLIES && (
+              <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                <input
+                  type="text"
+                  value={draftLabel}
+                  onChange={(e) => setDraftLabel(e.target.value.slice(0, QUICK_REPLY_LABEL_MAX))}
+                  placeholder="按鈕文字"
+                  className="w-32 rounded-md border border-input bg-background px-2 py-1 text-xs"
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      handleAddQuickReply();
+                    }
+                  }}
+                />
+                <input
+                  type="text"
+                  value={draftText}
+                  onChange={(e) => setDraftText(e.target.value)}
+                  placeholder="點擊後送出文字（可留空 = 同按鈕文字）"
+                  className="flex-1 min-w-[180px] rounded-md border border-input bg-background px-2 py-1 text-xs"
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      handleAddQuickReply();
+                    }
+                  }}
+                />
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-7 px-2 text-xs"
+                  onClick={handleAddQuickReply}
+                  disabled={!draftLabel.trim()}
+                >
+                  <Plus className="mr-1 h-3 w-3" />
+                  加入
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+
         <div className="flex items-end gap-2">
           {/* Attachment button */}
           <Button
@@ -181,9 +341,24 @@ export function MessageInput({
             <LayoutTemplate className="h-4 w-4" />
           </Button>
 
+          {/* Quick reply button (LINE only) */}
+          {supportsQuickReply && (
+            <Button
+              variant={quickReplies.length > 0 ? 'default' : 'ghost'}
+              size="icon"
+              className="h-9 w-9 shrink-0"
+              disabled={isDisabled}
+              onClick={() => setQuickReplyEditorOpen((v) => !v)}
+              title="加快速回覆按鈕"
+            >
+              <Zap className="h-4 w-4" />
+            </Button>
+          )}
+
           {/* Textarea */}
           <textarea
             ref={textareaRef}
+            data-message-input
             value={message}
             onChange={(e) => setMessage(e.target.value)}
             onKeyDown={handleKeyDown}

--- a/apps/web/src/components/inbox/TemplatePicker.tsx
+++ b/apps/web/src/components/inbox/TemplatePicker.tsx
@@ -26,10 +26,15 @@ interface TemplateItem {
   variables: TemplateVariable[];
 }
 
+interface QuickReplyItem {
+  label: string;
+  text?: string;
+}
+
 interface TemplatePickerProps {
   open: boolean;
   onClose: () => void;
-  onSelect: (text: string) => void;
+  onSelect: (text: string, extra?: { quickReplies?: QuickReplyItem[] }) => void;
   channelType?: string;
 }
 
@@ -92,11 +97,16 @@ export function TemplatePicker({ open, onClose, onSelect, channelType }: Templat
 
   if (!open) return null;
 
+  const extractQuickReplies = (tpl: TemplateItem): QuickReplyItem[] | undefined => {
+    const qr = (tpl.body as Record<string, unknown>).quickReplies;
+    return Array.isArray(qr) && qr.length > 0 ? (qr as QuickReplyItem[]) : undefined;
+  };
+
   const handleSelectTemplate = (tpl: TemplateItem) => {
     const keys = extractKeys(tpl.body);
     if (keys.length === 0) {
       // No variables — direct insert
-      onSelect(getBodyText(tpl.body));
+      onSelect(getBodyText(tpl.body), { quickReplies: extractQuickReplies(tpl) });
       onClose();
       return;
     }
@@ -116,7 +126,7 @@ export function TemplatePicker({ open, onClose, onSelect, channelType }: Templat
     if (!selected) return;
     const text = getBodyText(selected.body);
     const rendered = renderText(text, varValues);
-    onSelect(rendered);
+    onSelect(rendered, { quickReplies: extractQuickReplies(selected) });
     setSelected(null);
     setVarValues({});
     onClose();

--- a/apps/web/src/components/line/LineModuleTabs.tsx
+++ b/apps/web/src/components/line/LineModuleTabs.tsx
@@ -3,24 +3,37 @@
 /**
  * LINE 管理模組共用 Tab 列
  *
- * 目前只實作 Rich Menu；其餘 tab 為占位（disabled，提示「敬請期待」）。
+ * 切換 tab 走 router push 到對應頁。歡迎訊息 / 加好友自動回應為占位（尚未實作）。
  */
 
 import React from 'react';
+import { useRouter } from 'next/navigation';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 interface Props {
   active: string;
 }
 
+const TAB_TO_PATH: Record<string, string> = {
+  'rich-menus': '/dashboard/line/rich-menus',
+  'keyword-replies': '/dashboard/line/keyword-replies',
+};
+
 export function LineModuleTabs({ active }: Props) {
+  const router = useRouter();
+
+  const handleChange = (val: string) => {
+    const path = TAB_TO_PATH[val];
+    if (path && val !== active) router.push(path);
+  };
+
   return (
     <div className="border-b px-6 pt-2">
-      <Tabs value={active} onValueChange={() => undefined}>
+      <Tabs value={active} onValueChange={handleChange}>
         <TabsList>
           <TabsTrigger value="rich-menus">Rich Menu</TabsTrigger>
+          <TabsTrigger value="keyword-replies">關鍵字回覆</TabsTrigger>
           {/* 其餘 tab 用 placeholder 顯示「敬請期待」— Tabs 元件不支援 disabled，用樣式抑制 */}
-          <DisabledTab label="Quick Reply" />
           <DisabledTab label="歡迎訊息" />
           <DisabledTab label="加好友自動回應" />
         </TabsList>

--- a/apps/web/src/components/line/keyword-reply/KeywordReplyEditDialog.tsx
+++ b/apps/web/src/components/line/keyword-reply/KeywordReplyEditDialog.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { X, Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useMaterials } from '@/hooks/useMaterials';
+import type { KeywordReply, KeywordReplyInput } from '@/hooks/useKeywordReplies';
+
+interface Props {
+  open: boolean;
+  reply: KeywordReply | null; // null = 新建
+  onClose: () => void;
+  onSave: (input: KeywordReplyInput) => Promise<void>;
+}
+
+export function KeywordReplyEditDialog({ open, reply, onClose, onSave }: Props) {
+  const [name, setName] = useState('');
+  const [keywords, setKeywords] = useState<string[]>([]);
+  const [draftKeyword, setDraftKeyword] = useState('');
+  const [matchMode, setMatchMode] = useState<'any' | 'all'>('any');
+  const [materialId, setMaterialId] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // 列出所有 LINE 素材給選
+  const { materials } = useMaterials({ channelType: 'line', isActive: true, limit: 200 });
+
+  useEffect(() => {
+    if (open) {
+      setName(reply?.name ?? '');
+      setKeywords(reply?.keywords ?? []);
+      setMatchMode(reply?.matchMode ?? 'any');
+      setMaterialId(reply?.materialId ?? '');
+      setDraftKeyword('');
+      setError(null);
+    }
+  }, [open, reply]);
+
+  if (!open) return null;
+
+  const handleAddKeyword = () => {
+    const k = draftKeyword.trim();
+    if (!k) return;
+    if (keywords.includes(k)) return;
+    setKeywords([...keywords, k]);
+    setDraftKeyword('');
+  };
+
+  const handleRemoveKeyword = (idx: number) => {
+    setKeywords(keywords.filter((_, i) => i !== idx));
+  };
+
+  const handleSave = async () => {
+    if (!name.trim()) { setError('請輸入規則名稱'); return; }
+    if (keywords.length === 0) { setError('至少要 1 個關鍵字'); return; }
+    if (!materialId) { setError('請選擇要回覆的素材'); return; }
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave({
+        name: name.trim(),
+        keywords,
+        matchMode,
+        materialId,
+      });
+      onClose();
+    } catch (err: unknown) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      setError(((err as any)?.response?.data?.error?.message) ?? '儲存失敗');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const selectedMaterial = materials.find((m) => m.id === materialId);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div className="flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-lg bg-white shadow-xl">
+        <div className="flex items-center justify-between border-b px-5 py-3">
+          <div>
+            <h2 className="text-base font-semibold">
+              {reply ? '編輯關鍵字回覆' : '建立關鍵字回覆'}
+            </h2>
+            <p className="mt-0.5 text-xs text-slate-500">
+              當用戶在 LINE 傳訊息中出現指定關鍵字，自動回覆對應素材
+            </p>
+          </div>
+          <button type="button" onClick={onClose} className="text-slate-400 hover:text-slate-700">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="space-y-5 overflow-y-auto p-5">
+          {/* 規則名稱 */}
+          <div>
+            <label className="mb-1 block text-xs font-semibold text-slate-600">
+              規則名稱 *
+            </label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value.slice(0, 200))}
+              placeholder="例：詢問營業時間、預約諮詢、產品 DM"
+            />
+            <p className="mt-1 text-[11px] text-slate-500">只給管理用，用戶不會看到</p>
+          </div>
+
+          {/* 關鍵字 */}
+          <div>
+            <label className="mb-1 block text-xs font-semibold text-slate-600">
+              關鍵字 *
+            </label>
+            <div className="mb-2 flex flex-wrap items-center gap-1.5">
+              {keywords.map((k, idx) => (
+                <span
+                  key={idx}
+                  className="inline-flex items-center gap-1 rounded-full border border-blue-200 bg-blue-50 px-2.5 py-1 text-xs text-blue-900"
+                >
+                  {k}
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveKeyword(idx)}
+                    className="text-blue-400 hover:text-red-500"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </span>
+              ))}
+            </div>
+            <div className="flex items-center gap-1.5">
+              <Input
+                value={draftKeyword}
+                onChange={(e) => setDraftKeyword(e.target.value)}
+                placeholder="輸入關鍵字後按 Enter 或點「加入」"
+                className="flex-1 h-8 text-xs"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    handleAddKeyword();
+                  }
+                }}
+              />
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-8 px-2 text-xs"
+                onClick={handleAddKeyword}
+                disabled={!draftKeyword.trim()}
+              >
+                <Plus className="mr-1 h-3 w-3" />
+                加入
+              </Button>
+            </div>
+
+            {/* match mode */}
+            {keywords.length > 1 && (
+              <div className="mt-3 space-y-1">
+                <div className="text-xs font-medium text-slate-600">比對方式</div>
+                <div className="flex gap-3 text-xs">
+                  <label className="inline-flex items-center gap-1.5 cursor-pointer">
+                    <input
+                      type="radio"
+                      checked={matchMode === 'any'}
+                      onChange={() => setMatchMode('any')}
+                    />
+                    任一關鍵字出現就觸發（OR）
+                  </label>
+                  <label className="inline-flex items-center gap-1.5 cursor-pointer">
+                    <input
+                      type="radio"
+                      checked={matchMode === 'all'}
+                      onChange={() => setMatchMode('all')}
+                    />
+                    所有關鍵字都要出現才觸發（AND）
+                  </label>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* 素材選擇 */}
+          <div>
+            <label className="mb-1 block text-xs font-semibold text-slate-600">
+              回覆素材 *
+            </label>
+            <select
+              value={materialId}
+              onChange={(e) => setMaterialId(e.target.value)}
+              className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              <option value="">— 請選擇 —</option>
+              {materials.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.name}（{m.contentType}）
+                </option>
+              ))}
+            </select>
+            {selectedMaterial && (
+              <div className="mt-2 rounded border border-slate-200 bg-slate-50 px-3 py-2 text-xs">
+                <div className="font-medium">{selectedMaterial.name}</div>
+                <div className="text-slate-500">
+                  類型：{selectedMaterial.contentType}
+                  {selectedMaterial.category ? ` · 分類：${selectedMaterial.category}` : ''}
+                </div>
+                {selectedMaterial.variables && selectedMaterial.variables.length > 0 && (
+                  <div className="mt-1 text-amber-700">
+                    ⚠️ 此素材含 {selectedMaterial.variables.length} 個變數（{selectedMaterial.variables.map((v) => v.key).join(', ')}），會以預設值送出
+                  </div>
+                )}
+              </div>
+            )}
+            <p className="mt-1 text-[11px] text-slate-500">
+              素材在「行銷 → 素材庫」建立，這裡只列 LINE 渠道的素材
+            </p>
+          </div>
+
+          {error && (
+            <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t px-5 py-3">
+          <Button variant="outline" onClick={onClose} disabled={saving}>取消</Button>
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? '儲存中…' : '儲存'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/line/quick-reply/LinePreview.tsx
+++ b/apps/web/src/components/line/quick-reply/LinePreview.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+/**
+ * 模擬 LINE 聊天視窗的 Quick Reply 樣子
+ * 上方顯示一則範例訊息、下方是水平捲動的按鈕泡泡（仿 LINE 真實 UI）
+ */
+
+import React from 'react';
+
+interface QuickReplyItem {
+  label: string;
+  text?: string;
+}
+
+interface Props {
+  message?: string;
+  items: QuickReplyItem[];
+}
+
+export function LinePreview({ message = '請選擇：', items }: Props) {
+  return (
+    <div className="rounded-xl bg-[#8caab1] p-3">
+      {/* LINE OA 頭像 + bubble */}
+      <div className="flex items-start gap-2">
+        <div className="h-8 w-8 shrink-0 rounded-full bg-white shadow-sm" />
+        <div className="max-w-[80%] rounded-2xl bg-white px-3 py-2 text-sm text-slate-900 shadow-sm">
+          {message}
+        </div>
+      </div>
+
+      {/* Quick reply 按鈕列（水平捲動） */}
+      {items.length > 0 ? (
+        <div className="mt-2 flex gap-1.5 overflow-x-auto pb-1 pl-10">
+          {items.map((it, idx) => (
+            <button
+              key={idx}
+              type="button"
+              className="shrink-0 rounded-full border border-white bg-transparent px-3 py-1 text-xs font-medium text-white shadow-sm hover:bg-white/10"
+              title={it.text ? `點擊後送出：${it.text}` : `點擊後送出：${it.label}`}
+            >
+              {it.label}
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className="mt-2 pl-10 text-[11px] text-white/70">
+          （新增按鈕後會顯示在這裡）
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/line/quick-reply/PresetEditDialog.tsx
+++ b/apps/web/src/components/line/quick-reply/PresetEditDialog.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { QuickReplyEditor, type QuickReplyItem } from '@/components/materials/QuickReplyEditor';
+import { LinePreview } from './LinePreview';
+import type { QuickReplyPreset } from '@/hooks/useQuickReplyPresets';
+
+interface Props {
+  open: boolean;
+  preset: QuickReplyPreset | null; // null = 新建模式
+  onClose: () => void;
+  onSave: (data: { name: string; items: QuickReplyItem[] }) => Promise<void>;
+}
+
+export function PresetEditDialog({ open, preset, onClose, onSave }: Props) {
+  const [name, setName] = useState('');
+  const [items, setItems] = useState<QuickReplyItem[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setName(preset?.name ?? '');
+      setItems(preset?.items ?? []);
+      setError(null);
+    }
+  }, [open, preset]);
+
+  if (!open) return null;
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      setError('請輸入名稱');
+      return;
+    }
+    if (items.length === 0) {
+      setError('至少要 1 個按鈕');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave({ name: name.trim(), items });
+      onClose();
+    } catch (err: unknown) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      setError(((err as any)?.response?.data?.error?.message) ?? '儲存失敗');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div className="flex max-h-[90vh] w-full max-w-4xl flex-col overflow-hidden rounded-lg bg-white shadow-xl">
+        <div className="flex items-center justify-between border-b px-5 py-3">
+          <div>
+            <h2 className="text-base font-semibold">
+              {preset ? '編輯預設組' : '建立 Quick Reply 預設組'}
+            </h2>
+            <p className="mt-0.5 text-xs text-slate-500">
+              建好後客服回訊息時可一鍵套用，省去每次手刻按鈕
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-slate-400 hover:text-slate-700"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="grid flex-1 grid-cols-1 gap-4 overflow-y-auto p-5 md:grid-cols-[1fr,320px]">
+          {/* 左：編輯區 */}
+          <div className="space-y-4">
+            <div>
+              <label className="mb-1 block text-xs font-semibold text-slate-600">
+                這組叫什麼名字？*
+              </label>
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value.slice(0, 100))}
+                placeholder="例：滿意度調查、預約時段、是否同意條款"
+              />
+              <p className="mt-1 text-[11px] text-slate-500">
+                只是給你自己辨識用，不會給用戶看
+              </p>
+            </div>
+
+            <div>
+              <label className="mb-1 block text-xs font-semibold text-slate-600">
+                按鈕設定
+              </label>
+              <div className="mb-2 rounded border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-[11px] text-slate-600">
+                <strong>按鈕文字</strong>：用戶在 LINE 看到的按鈕字（≤ 20 字）<br />
+                <strong>點擊後送出文字</strong>：用戶點下去後，系統幫他送什麼訊息給客服（留空就送同按鈕文字）
+              </div>
+              <QuickReplyEditor value={items} onChange={setItems} />
+            </div>
+
+            {error && (
+              <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                {error}
+              </div>
+            )}
+          </div>
+
+          {/* 右：即時預覽 */}
+          <aside className="space-y-2">
+            <div className="text-xs font-semibold uppercase tracking-wide text-slate-600">
+              用戶在 LINE 看到的樣子
+            </div>
+            <LinePreview message="請選擇您要的選項：" items={items} />
+            <p className="text-[11px] text-slate-500">
+              用戶點按鈕後，會自動送出你設定的「點擊後送出文字」進到對話
+            </p>
+          </aside>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t px-5 py-3">
+          <Button variant="outline" onClick={onClose} disabled={saving}>
+            取消
+          </Button>
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? '儲存中…' : '儲存'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/materials/MaterialEditor.tsx
+++ b/apps/web/src/components/materials/MaterialEditor.tsx
@@ -22,6 +22,7 @@ import { LineImagemapEditor } from './line/LineImagemapEditor';
 import { LineVideoEditor } from './line/LineVideoEditor';
 import { LineFlexShowcaseEditor } from './line/showcase/LineFlexShowcaseEditor';
 import { MaterialPreview } from './MaterialPreview';
+import { QuickReplyEditor, type QuickReplyItem } from './QuickReplyEditor';
 import type { MaterialVariable } from '@/hooks/useMaterials';
 
 export interface MaterialDraft {
@@ -148,6 +149,22 @@ export function MaterialEditor({ draft, templateName, saving, onChange, onSave, 
               <div className="text-xs text-slate-500">此版型暫無視覺化編輯器</div>
             )}
           </section>
+
+          {/* Quick Reply（LINE 專用） */}
+          {draft.channelType === 'line' && (
+            <section className="space-y-3 rounded-lg border border-slate-200 p-4">
+              <div className="text-sm font-semibold">快速回覆按鈕（選填）</div>
+              <QuickReplyEditor
+                value={(draft.body.quickReplies as QuickReplyItem[] | undefined) ?? []}
+                onChange={(next) =>
+                  onChange({
+                    ...draft,
+                    body: { ...draft.body, quickReplies: next.length > 0 ? next : undefined },
+                  })
+                }
+              />
+            </section>
+          )}
         </div>
 
         {showPreview && (

--- a/apps/web/src/components/materials/QuickReplyEditor.tsx
+++ b/apps/web/src/components/materials/QuickReplyEditor.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Plus, X } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+export interface QuickReplyItem {
+  label: string;
+  text?: string;
+}
+
+interface Props {
+  value: QuickReplyItem[];
+  onChange: (next: QuickReplyItem[]) => void;
+}
+
+const MAX_QUICK_REPLIES = 13;
+const LABEL_MAX = 20;
+
+export function QuickReplyEditor({ value, onChange }: Props) {
+  const [draftLabel, setDraftLabel] = useState('');
+  const [draftText, setDraftText] = useState('');
+
+  const handleAdd = () => {
+    const label = draftLabel.trim();
+    if (!label) return;
+    if (value.length >= MAX_QUICK_REPLIES) return;
+    onChange([...value, { label, text: draftText.trim() || undefined }]);
+    setDraftLabel('');
+    setDraftText('');
+  };
+
+  const handleRemove = (idx: number) => {
+    onChange(value.filter((_, i) => i !== idx));
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="text-xs text-slate-500">
+        最多 {MAX_QUICK_REPLIES} 個按鈕，會顯示在訊息底部供用戶點擊（{value.length}/{MAX_QUICK_REPLIES}）
+      </div>
+
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {value.map((qr, idx) => (
+            <span
+              key={idx}
+              className="inline-flex items-center gap-1 rounded-full border border-slate-300 bg-white px-2.5 py-1 text-xs"
+              title={qr.text ? `送出文字：${qr.text}` : `送出文字：${qr.label}`}
+            >
+              <span className="font-medium">{qr.label}</span>
+              {qr.text && qr.text !== qr.label && (
+                <span className="text-slate-400">→ {qr.text}</span>
+              )}
+              <button
+                type="button"
+                className="ml-0.5 text-slate-400 hover:text-red-500"
+                onClick={() => handleRemove(idx)}
+                title="移除"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+
+      {value.length < MAX_QUICK_REPLIES && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Input
+            value={draftLabel}
+            onChange={(e) => setDraftLabel(e.target.value.slice(0, LABEL_MAX))}
+            placeholder="例：同意"
+            className="w-32 h-8 text-xs"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleAdd();
+              }
+            }}
+          />
+          <Input
+            value={draftText}
+            onChange={(e) => setDraftText(e.target.value)}
+            placeholder="例：我同意（可留空 = 直接送「同意」）"
+            className="flex-1 min-w-[200px] h-8 text-xs"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleAdd();
+              }
+            }}
+          />
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 px-2 text-xs"
+            onClick={handleAdd}
+            disabled={!draftLabel.trim()}
+          >
+            <Plus className="mr-1 h-3 w-3" />
+            加入
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/useKbFeedback.ts
+++ b/apps/web/src/hooks/useKbFeedback.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import useSWR from 'swr';
+import api from '@/lib/api';
+
+export interface KbFeedbackItem {
+  id: string;
+  articleId: string;
+  messageId: string | null;
+  userQuestion: string | null;
+  botReply: string | null;
+  confidence: number | null;
+  rating: string;
+  status: string;
+  createdAt: string;
+  article?: { id: string; title: string; externalDocId: string | null };
+}
+
+const fetcher = async (url: string) => {
+  const res = await api.get(url);
+  return res.data;
+};
+
+/** 各文章 open 回報數 map：{ [articleId]: count } */
+export function useKbFeedbackCounts() {
+  const { data, error, isLoading, mutate } = useSWR('/knowledge/feedback/counts', fetcher);
+  return {
+    counts: (data?.data ?? {}) as Record<string, number>,
+    isLoading,
+    error,
+    mutate,
+  };
+}
+
+/** 回報明細，可依 articleId / status 過濾 */
+export function useKbFeedbackList(opts: { articleId?: string; status?: string } = {}) {
+  const params = new URLSearchParams();
+  if (opts.articleId) params.set('articleId', opts.articleId);
+  if (opts.status) params.set('status', opts.status);
+  const qs = params.toString();
+  const key = `/knowledge/feedback${qs ? `?${qs}` : ''}`;
+  const { data, error, isLoading, mutate } = useSWR(key, fetcher);
+  return {
+    feedback: (data?.data ?? []) as KbFeedbackItem[],
+    isLoading,
+    error,
+    mutate,
+  };
+}
+
+export async function resolveKbFeedback(id: string): Promise<void> {
+  await api.patch(`/knowledge/feedback/${id}/resolve`);
+}

--- a/apps/web/src/hooks/useKeywordReplies.ts
+++ b/apps/web/src/hooks/useKeywordReplies.ts
@@ -1,0 +1,145 @@
+'use client';
+
+/**
+ * Keyword Reply hook — 在 automation rules 之上的薄包裝。
+ *
+ * 「關鍵字回覆」= 一條結構固定的 automation rule：
+ *   - trigger.type = 'keyword.matched'
+ *   - 至少有一個 action.type = 'send_material'
+ *
+ * 此 hook 過濾出符合這個結構的 rule，並把它們呈現為簡化的「關鍵字 → 素材」模型。
+ * 不額外建 KeywordReply 表，沿用 automation 引擎所有保護機制（rate limit / opt-out / AGENT_HANDLED）。
+ */
+
+import useSWR from 'swr';
+import api from '@/lib/api';
+
+const fetcher = async (url: string) => {
+  const res = await api.get(url);
+  return res.data;
+};
+
+interface AutomationRuleRaw {
+  id: string;
+  name: string;
+  description?: string;
+  trigger?: { type?: string; keywords?: string[]; match_mode?: string };
+  isActive: boolean;
+  priority: number;
+  createdAt: string;
+  // 列表 API 不一定回 actions，所以需 detail 抓
+}
+
+interface AutomationRuleDetail extends AutomationRuleRaw {
+  actions: Array<{ type: string; params: Record<string, unknown> }>;
+}
+
+export interface KeywordReply {
+  id: string;
+  name: string;
+  keywords: string[];
+  matchMode: 'any' | 'all';
+  materialId: string;
+  isActive: boolean;
+  createdAt: string;
+}
+
+function isKeywordReplyRule(rule: AutomationRuleDetail): boolean {
+  if (rule.trigger?.type !== 'keyword.matched') return false;
+  return rule.actions?.some((a) => a.type === 'send_material');
+}
+
+function ruleToKeywordReply(rule: AutomationRuleDetail): KeywordReply | null {
+  if (!isKeywordReplyRule(rule)) return null;
+  const sendMaterial = rule.actions.find((a) => a.type === 'send_material');
+  const materialId = sendMaterial?.params?.materialId as string | undefined;
+  if (!materialId) return null;
+  return {
+    id: rule.id,
+    name: rule.name,
+    keywords: rule.trigger?.keywords ?? [],
+    matchMode: (rule.trigger?.match_mode as 'any' | 'all') ?? 'any',
+    materialId,
+    isActive: rule.isActive,
+    createdAt: rule.createdAt,
+  };
+}
+
+/**
+ * 列出所有「關鍵字回覆」rules。
+ * 1. 用 /automation/rules?trigger=keyword.matched 先窄化
+ * 2. 對每條 rule fetch 完整 detail（拿 actions）
+ * 3. 過濾出含 send_material 的
+ */
+export function useKeywordReplies() {
+  const { data, error, isLoading, mutate } = useSWR(
+    '/automation/rules?trigger=keyword.matched&limit=100',
+    fetcher,
+  );
+
+  const list = (data?.data ?? []) as AutomationRuleRaw[];
+
+  // 用第二輪請求補 actions
+  const { data: detailData } = useSWR(
+    list.length > 0 ? ['keyword-reply-details', list.map((r) => r.id).join(',')] : null,
+    async () => {
+      const details = await Promise.all(
+        list.map((r) => api.get(`/automation/rules/${r.id}`).then((res) => res.data.data)),
+      );
+      return details as AutomationRuleDetail[];
+    },
+  );
+
+  const replies = (detailData ?? [])
+    .map(ruleToKeywordReply)
+    .filter((x): x is KeywordReply => x !== null);
+
+  return { replies, isLoading, error, mutate };
+}
+
+// ─── CRUD helpers ──────────────────────────────────────────────────────
+
+export interface KeywordReplyInput {
+  name: string;
+  keywords: string[];
+  matchMode: 'any' | 'all';
+  materialId: string;
+}
+
+function buildRulePayload(input: KeywordReplyInput): Record<string, unknown> {
+  return {
+    name: input.name,
+    trigger: {
+      type: 'keyword.matched',
+      keywords: input.keywords,
+      match_mode: input.matchMode,
+    },
+    // 空條件群組 — keyword 比對已在 trigger 內，不需額外 fact 條件
+    conditions: { all: [] },
+    actions: [
+      {
+        type: 'send_material',
+        params: { materialId: input.materialId },
+      },
+    ],
+  };
+}
+
+export async function createKeywordReply(input: KeywordReplyInput): Promise<void> {
+  await api.post('/automation/rules', buildRulePayload(input));
+}
+
+export async function updateKeywordReply(
+  id: string,
+  input: KeywordReplyInput,
+): Promise<void> {
+  await api.patch(`/automation/rules/${id}`, buildRulePayload(input));
+}
+
+export async function deleteKeywordReply(id: string): Promise<void> {
+  await api.delete(`/automation/rules/${id}`);
+}
+
+export async function toggleKeywordReply(id: string, isActive: boolean): Promise<void> {
+  await api.patch(`/automation/rules/${id}`, { isActive });
+}

--- a/apps/web/src/hooks/useMessages.ts
+++ b/apps/web/src/hooks/useMessages.ts
@@ -94,7 +94,11 @@ export function useMessages(conversationId: string | null, filters: MessageFilte
   }, [conversationId, limit, loadingOlder, hasMore]);
 
   const sendMessage = useCallback(
-    async (content: string, contentType: string = 'text') => {
+    async (
+      content: string,
+      contentType: string = 'text',
+      extraContent?: Record<string, unknown>,
+    ) => {
       if (!conversationId) return;
 
       const body: { content: Record<string, unknown> | string; contentType: string } = {
@@ -109,6 +113,11 @@ export function useMessages(conversationId: string | null, filters: MessageFilte
         } catch {
           body.content = { url: content };
         }
+      }
+
+      // Merge extra content fields (e.g. quickReplies)，由呼叫者決定塞什麼
+      if (extraContent && typeof body.content === 'object' && body.content !== null) {
+        body.content = { ...(body.content as Record<string, unknown>), ...extraContent };
       }
 
       const res = await api.post(`/conversations/${conversationId}/messages`, body);

--- a/apps/web/src/hooks/useQuickReplyPresets.ts
+++ b/apps/web/src/hooks/useQuickReplyPresets.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import useSWR from 'swr';
+import api from '@/lib/api';
+
+export interface QuickReplyItem {
+  label: string;
+  text?: string;
+}
+
+export interface QuickReplyPreset {
+  id: string;
+  tenantId: string;
+  name: string;
+  items: QuickReplyItem[];
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreatePresetPayload {
+  name: string;
+  items: QuickReplyItem[];
+}
+
+export interface UpdatePresetPayload {
+  name?: string;
+  items?: QuickReplyItem[];
+  isActive?: boolean;
+}
+
+const fetcher = async (url: string) => {
+  const res = await api.get(url);
+  return res.data;
+};
+
+export function useQuickReplyPresets() {
+  const { data, error, isLoading, mutate } = useSWR('/line/quick-reply-presets', fetcher);
+  return {
+    presets: (data?.data ?? []) as QuickReplyPreset[],
+    isLoading,
+    error,
+    mutate,
+  };
+}
+
+export async function createQuickReplyPreset(
+  payload: CreatePresetPayload,
+): Promise<QuickReplyPreset> {
+  const res = await api.post('/line/quick-reply-presets', payload);
+  return res.data.data;
+}
+
+export async function updateQuickReplyPreset(
+  id: string,
+  payload: UpdatePresetPayload,
+): Promise<QuickReplyPreset> {
+  const res = await api.patch(`/line/quick-reply-presets/${id}`, payload);
+  return res.data.data;
+}
+
+export async function deleteQuickReplyPreset(id: string): Promise<void> {
+  await api.delete(`/line/quick-reply-presets/${id}`);
+}

--- a/apps/web/src/hooks/useRichMenus.ts
+++ b/apps/web/src/hooks/useRichMenus.ts
@@ -121,3 +121,13 @@ export async function duplicateRichMenu(id: string): Promise<RichMenu> {
   const res = await api.post(`/line/rich-menus/${id}/duplicate`);
   return res.data.data;
 }
+
+export async function publishRichMenu(id: string): Promise<RichMenu> {
+  const res = await api.post(`/line/rich-menus/${id}/publish`);
+  return res.data.data;
+}
+
+export async function unpublishRichMenu(id: string): Promise<RichMenu> {
+  const res = await api.post(`/line/rich-menus/${id}/unpublish`);
+  return res.data.data;
+}

--- a/apps/workers/src/handlers/automation.handler.ts
+++ b/apps/workers/src/handlers/automation.handler.ts
@@ -1,6 +1,7 @@
 import type { Job } from 'bullmq';
 import type { PrismaClient } from '@prisma/client';
 import type IORedis from 'ioredis';
+import type { ChannelPlugin } from '@open333crm/channel-plugins';
 import { logger } from '@open333crm/core';
 import { evaluateRules, validateAutomationRuleContract } from '@open333crm/automation';
 import { publishSocketEvent } from '../lib/socket-bridge.js';
@@ -19,6 +20,7 @@ export async function handleAutomationJob(
   job: Job,
   prisma: PrismaClient,
   redisPublisher: IORedis,
+  pluginRegistry?: Map<string, ChannelPlugin>,
 ): Promise<void> {
   const { tenantId, trigger, context } = job.data as AutomationJobData;
 
@@ -69,12 +71,17 @@ export async function handleAutomationJob(
           ? facts['case.id']
           : null;
 
+    const conversationId =
+      typeof context['conversationId'] === 'string' ? context['conversationId'] : null;
+
     await executeWorkerAutomationActions(prisma, redisPublisher, match.actions, {
       tenantId,
       caseId,
+      conversationId,
       assigneeId:
         typeof facts['case.assigneeId'] === 'string' ? facts['case.assigneeId'] : null,
       title: typeof context['title'] === 'string' ? context['title'] : null,
+      pluginRegistry,
     });
 
     await publishSocketEvent(

--- a/apps/workers/src/index.ts
+++ b/apps/workers/src/index.ts
@@ -107,7 +107,7 @@ async function main() {
     'automation',
     async (job) => {
       logger.info(`[automation] Processing job ${job.id}: ${job.name}`);
-      await handleAutomationJob(job, prisma, redisPublisher);
+      await handleAutomationJob(job, prisma, redisPublisher, pluginRegistry);
     },
     { connection },
   );

--- a/apps/workers/src/lib/automation-actions.ts
+++ b/apps/workers/src/lib/automation-actions.ts
@@ -1,9 +1,11 @@
 import type { PrismaClient } from '@prisma/client';
 import type IORedis from 'ioredis';
+import type { ChannelPlugin } from '@open333crm/channel-plugins';
 import { bumpSlaPriority } from '@open333crm/shared';
 import { logger } from '@open333crm/core';
 import { publishSocketEvent } from './socket-bridge.js';
 import { enqueueNotification } from './notification-queue.js';
+import { deliverToChannelFromWorker, renderTemplateBody } from './channel-delivery.js';
 
 export interface WorkerAutomationAction {
   type: string;
@@ -14,8 +16,11 @@ export interface WorkerAutomationAction {
 export interface WorkerActionContext {
   tenantId: string;
   caseId?: string | null;
+  conversationId?: string | null;
   assigneeId?: string | null;
   title?: string | null;
+  // 送 channel 訊息（send_message / send_material）需要 plugin registry + redis
+  pluginRegistry?: Map<string, ChannelPlugin>;
 }
 
 async function getSupervisorAndAdminIds(
@@ -129,6 +134,76 @@ export async function executeWorkerAutomationActions(
             clickUrl: context.caseId ? `/dashboard/cases/${context.caseId}` : undefined,
           });
         }
+        continue;
+      }
+
+      // ── OUTBOUND actions（需 conversationId + pluginRegistry，主要用於 keyword.matched 對話回覆）──
+
+      if (action.type === 'send_message') {
+        if (!context.conversationId || !context.pluginRegistry) {
+          logger.info('[automation] send_message skipped: missing conversationId/pluginRegistry');
+          continue;
+        }
+        const text = String(params['text'] ?? params['message'] ?? '');
+        if (!text) {
+          logger.info('[automation] send_message skipped: empty text');
+          continue;
+        }
+        await deliverToChannelFromWorker(
+          prisma,
+          redisPublisher,
+          context.pluginRegistry,
+          context.conversationId,
+          { contentType: 'text', content: { text } },
+        );
+        continue;
+      }
+
+      if (action.type === 'send_material') {
+        if (!context.conversationId || !context.pluginRegistry) {
+          logger.info('[automation] send_material skipped: missing conversationId/pluginRegistry');
+          continue;
+        }
+        const materialId = params['materialId'];
+        if (typeof materialId !== 'string' || !materialId) {
+          logger.info('[automation] send_material skipped: missing materialId');
+          continue;
+        }
+        const material = await prisma.material.findFirst({
+          where: { id: materialId, tenantId: context.tenantId },
+          select: { contentType: true, body: true, channelType: true },
+        });
+        if (!material) {
+          logger.warn(`[automation] send_material skipped: material ${materialId} not found`);
+          continue;
+        }
+
+        // channel 防呆：素材 channelType 與對話 channel 不符就 skip（避免 FB 對話送 line_* 空訊息）
+        const conv = await prisma.conversation.findFirst({
+          where: { id: context.conversationId, tenantId: context.tenantId },
+          include: { channel: { select: { channelType: true } } },
+        });
+        const convChannelType = conv?.channel?.channelType?.toLowerCase();
+        const matChannelType = material.channelType?.toLowerCase();
+        if (convChannelType && matChannelType && convChannelType !== matChannelType) {
+          logger.warn(
+            `[automation] send_material skipped: material channel "${matChannelType}" != conversation channel "${convChannelType}"`,
+          );
+          continue;
+        }
+
+        const variables = (params['variables'] as Record<string, string> | undefined) ?? {};
+        const renderedBody = renderTemplateBody(
+          material.body as Record<string, unknown>,
+          variables,
+        );
+        await deliverToChannelFromWorker(
+          prisma,
+          redisPublisher,
+          context.pluginRegistry,
+          context.conversationId,
+          { contentType: material.contentType, content: renderedBody },
+        );
         continue;
       }
 

--- a/apps/workers/src/lib/channel-delivery.ts
+++ b/apps/workers/src/lib/channel-delivery.ts
@@ -1,0 +1,149 @@
+/**
+ * Worker 端送訊息到 channel（LINE / FB）。
+ *
+ * worker 是獨立進程、沒有 fastify.io，但有 channel plugin registry + Redis。
+ * 流程：查 conversation+identity → 解密 credentials → plugin.sendMessage →
+ * 寫 OUTBOUND message → 透過 socket bridge emit message.new 給前端 inbox。
+ *
+ * 對齊 apps/api conversation.service.ts 的 deliverToChannel。
+ */
+
+import type { PrismaClient } from '@prisma/client';
+import type IORedis from 'ioredis';
+import type { ChannelPlugin } from '@open333crm/channel-plugins';
+import { logger } from '@open333crm/core';
+import { decryptCredentials } from './credentials.js';
+import { publishSocketEvent } from './socket-bridge.js';
+
+export interface DeliverPayload {
+  contentType: string;
+  content: Record<string, unknown>;
+}
+
+/**
+ * 把訊息送出 channel，並寫 OUTBOUND message + emit message.new。
+ * 回傳是否送出成功（找不到 conversation/identity/plugin 會 return false）。
+ */
+export async function deliverToChannelFromWorker(
+  prisma: PrismaClient,
+  redis: IORedis,
+  pluginRegistry: Map<string, ChannelPlugin>,
+  conversationId: string,
+  payload: DeliverPayload,
+): Promise<boolean> {
+  const conv = await prisma.conversation.findUnique({
+    where: { id: conversationId },
+    include: {
+      channel: true,
+      contact: { include: { channelIdentities: true } },
+    },
+  });
+
+  if (!conv) {
+    logger.error('[worker:deliver] Conversation not found:', conversationId);
+    return false;
+  }
+  if (!conv.channel?.isActive) {
+    logger.error('[worker:deliver] Channel inactive/missing for conv:', conversationId);
+    return false;
+  }
+
+  const identity = conv.contact?.channelIdentities?.find(
+    (ci) => ci.channelId === conv.channel.id,
+  );
+  if (!identity) {
+    logger.error('[worker:deliver] No channel identity for contact on channel', conv.channel.id);
+    return false;
+  }
+
+  const plugin = pluginRegistry.get(conv.channel.channelType);
+  if (!plugin) {
+    logger.error('[worker:deliver] No plugin for channelType:', conv.channel.channelType);
+    return false;
+  }
+
+  let credentials: Record<string, unknown>;
+  try {
+    credentials = decryptCredentials(conv.channel.credentialsEncrypted);
+  } catch (err) {
+    logger.error('[worker:deliver] Failed to decrypt credentials:', err);
+    return false;
+  }
+
+  const now = new Date();
+
+  // 1. 呼叫 channel plugin 送出
+  let channelMsgId: string | undefined;
+  try {
+    const result = await plugin.sendMessage(identity.uid, payload, credentials);
+    if (!result.success) {
+      logger.error('[worker:deliver] plugin.sendMessage failed:', result.error);
+      return false;
+    }
+    channelMsgId = result.channelMsgId;
+  } catch (err) {
+    logger.error('[worker:deliver] plugin.sendMessage threw:', err);
+    return false;
+  }
+
+  // 2. 寫 OUTBOUND message 進 DB
+  const message = await prisma.message.create({
+    data: {
+      conversationId,
+      direction: 'OUTBOUND',
+      senderType: 'SYSTEM',
+      contentType: payload.contentType,
+      content: payload.content as object,
+      channelMsgId: channelMsgId ?? null,
+      metadata: { source: 'automation' },
+      createdAt: now,
+    },
+  });
+
+  await prisma.conversation.update({
+    where: { id: conversationId },
+    data: { lastMessageAt: now },
+  });
+
+  // 3. emit message.new 給前端 inbox（透過 redis socket bridge）
+  const wsPayload = {
+    conversationId,
+    message: {
+      id: message.id,
+      conversationId,
+      direction: 'OUTBOUND',
+      senderType: 'SYSTEM',
+      contentType: payload.contentType,
+      content: payload.content,
+      createdAt: now.toISOString(),
+      sender: null,
+    },
+  };
+  await publishSocketEvent(redis, `conversation:${conversationId}`, 'message.new', wsPayload);
+  await publishSocketEvent(redis, `tenant:${conv.tenantId}`, 'message.new', wsPayload);
+
+  logger.info(`[worker:deliver] sent ${payload.contentType} to conv=${conversationId} uid=${identity.uid}`);
+  return true;
+}
+
+/**
+ * 遞迴替換 body 內的 {{key}} 變數（對齊 api template-renderer，worker 端輕量複製）。
+ */
+export function renderTemplateBody<T>(body: T, variables: Record<string, string>): T {
+  if (typeof body === 'string') {
+    return body.replace(/\{\{([a-zA-Z0-9_.]+)\}\}/g, (_m, key: string) =>
+      variables[key] !== undefined ? variables[key] : `{{${key}}}`,
+    ) as unknown as T;
+  }
+  if (Array.isArray(body)) {
+    return body.map((item) => renderTemplateBody(item, variables)) as unknown as T;
+  }
+  if (body !== null && typeof body === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(body)) {
+      result[k] = renderTemplateBody(v, variables);
+    }
+    return result as T;
+  }
+  return body;
+}

--- a/packages/automation/src/contracts/actions.ts
+++ b/packages/automation/src/contracts/actions.ts
@@ -52,6 +52,21 @@ export const AUTOMATION_ACTION_DEFINITIONS: readonly AutomationActionDefinition[
     mutates: ['conversation', 'message'],
   },
   {
+    type: 'send_material',
+    label: '傳送素材',
+    requires: ['contact', 'conversation'],
+    mutates: ['conversation', 'message'],
+    params: [
+      {
+        key: 'materialId',
+        label: '素材 ID',
+        type: 'string',
+        required: true,
+        placeholder: '從素材庫選擇要送出的素材',
+      },
+    ],
+  },
+  {
     type: 'create_case',
     label: '建立工單',
     requires: ['contact'],

--- a/packages/database/prisma/migrations/20260525073221_add_quick_reply_presets/migration.sql
+++ b/packages/database/prisma/migrations/20260525073221_add_quick_reply_presets/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "quick_reply_presets" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "tenantId" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "items" JSONB NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "quick_reply_presets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "quick_reply_presets_tenantId_isActive_idx" ON "quick_reply_presets"("tenantId", "isActive");
+
+-- AddForeignKey
+ALTER TABLE "quick_reply_presets" ADD CONSTRAINT "quick_reply_presets_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "tenants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/database/prisma/migrations/20260528065940_add_kb_article_feedback/migration.sql
+++ b/packages/database/prisma/migrations/20260528065940_add_kb_article_feedback/migration.sql
@@ -1,0 +1,28 @@
+-- CreateTable
+CREATE TABLE "kb_article_feedback" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "tenantId" UUID NOT NULL,
+    "articleId" UUID NOT NULL,
+    "messageId" UUID,
+    "userQuestion" TEXT,
+    "botReply" TEXT,
+    "confidence" DOUBLE PRECISION,
+    "rating" TEXT NOT NULL DEFAULT 'bad',
+    "contactId" UUID,
+    "status" TEXT NOT NULL DEFAULT 'open',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "kb_article_feedback_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "kb_article_feedback_tenantId_articleId_idx" ON "kb_article_feedback"("tenantId", "articleId");
+
+-- CreateIndex
+CREATE INDEX "kb_article_feedback_tenantId_status_idx" ON "kb_article_feedback"("tenantId", "status");
+
+-- AddForeignKey
+ALTER TABLE "kb_article_feedback" ADD CONSTRAINT "kb_article_feedback_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "tenants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "kb_article_feedback" ADD CONSTRAINT "kb_article_feedback_articleId_fkey" FOREIGN KEY ("articleId") REFERENCES "km_articles"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -219,6 +219,8 @@ model Tenant {
   materials               Material[]
   richMenus               RichMenu[]
   chatboxSessions         ChatboxSession[]
+  quickReplyPresets       QuickReplyPreset[]
+  kbArticleFeedback       KbArticleFeedback[]
 
   @@map("tenants")
 }
@@ -849,6 +851,7 @@ model KmArticle {
   createdAt      DateTime                     @default(now())
 
   attachments KmArticleAttachment[]
+  feedback    KbArticleFeedback[]
 
   @@unique([tenantId, externalDocId])
   @@index([tenantId, status])
@@ -1533,5 +1536,49 @@ model PartnerApiKey {
   @@index([tenantId, isActive])
   @@index([keyPrefix])
   @@map("partner_api_keys")
+}
+
+// ─────────────────────────────────────────────
+// Quick Reply Preset（LINE 客服可重用的快速回覆按鈕組）
+// ─────────────────────────────────────────────
+
+model QuickReplyPreset {
+  id        String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId  String   @db.Uuid
+  name      String
+  items     Json
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  tenant Tenant @relation(fields: [tenantId], references: [id])
+
+  @@index([tenantId, isActive])
+  @@map("quick_reply_presets")
+}
+
+// ─────────────────────────────────────────────
+// KB 文章回報（AI 回答品質回饋迴路：測試者/用戶回報答案不好 → 後台調教 KB）
+// ─────────────────────────────────────────────
+
+model KbArticleFeedback {
+  id           String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId     String   @db.Uuid
+  articleId    String   @db.Uuid
+  messageId    String?  @db.Uuid
+  userQuestion String?
+  botReply     String?
+  confidence   Float?
+  rating       String   @default("bad")
+  contactId    String?  @db.Uuid
+  status       String   @default("open")
+  createdAt    DateTime @default(now())
+
+  tenant  Tenant    @relation(fields: [tenantId], references: [id])
+  article KmArticle @relation(fields: [articleId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId, articleId])
+  @@index([tenantId, status])
+  @@map("kb_article_feedback")
 }
 


### PR DESCRIPTION
## Summary

本 PR 涵蓋四個相關功能，共用 `deliverToChannel` 物件化與 LINE quick reply payload 基礎：

### 1. LINE Quick Reply
- `deliverToChannel` 擴展接受 `{ contentType, content }`（含 quickReplies）
- 客服 MessageInput 可加 quick reply 按鈕、套用預設組
- MessageTemplate 可存 quickReplies、TemplatePicker 帶出
- 新增 `QuickReplyPreset` model + 管理頁 `/dashboard/line/quick-replies`

### 2. LINE 關鍵字回覆
- 新增 `send_material` automation action（送素材庫圖/Flex/輪播）
- 管理頁 `/dashboard/line/keyword-replies`（底層 `keyword.matched` + `send_material`）
- kb-autoreply 偵測 keyword 規則命中時讓步，避免 KB 搶答

### 3. KB 回答品質回報（調教回饋迴路）
- 新增 `KbArticleFeedback` model
- bot KB 回答附「👎 沒幫到我」quick reply postback
- webhook 攔截 `kb_feedback` postback → 記問句+命中文章（仿 CSAT，不觸發 automation）
- 知識庫頁新增「回報調教」tab：回報列表 → 編輯文章 → 標已處理

### 4. Rich Menu publish + 其他
- rich-menu publish/unpublish（建 LINE richmenu + 上傳圖 + 設 default）
- notification/automation worker 改 lazy Queue（修 dotenv 載入前讀 default redis port 噴錯）

## Migrations
- `add_quick_reply_presets`
- `add_kb_article_feedback`

> 部署時跑 `prisma migrate deploy`

## Test plan

- [x] api + web typecheck 雙綠
- [x] 本機 migration deploy + prisma generate
- [x] dev 重啟無錯、新 endpoint 掛上（401 auth 正常）
- [ ] **UAT 部署後端到端**：LINE 問 KB 問題 → bot 回答附「👎」按鈕 → 點擊 → 後台「回報調教」tab 看到記錄
- [ ] 關鍵字回覆：LINE 傳關鍵字 → 自動回素材
- [ ] CSAT postback 回歸（與 kb_feedback prefix 不衝突）

🤖 Generated with [Claude Code](https://claude.com/claude-code)