### PR TITLE
feat(bot): handoff 提示可設定（取代 KB 回答尾巴的寫死文字）

### DIFF
--- a/apps/api/src/modules/ai/kb-autoreply.service.ts
+++ b/apps/api/src/modules/ai/kb-autoreply.service.ts
@@ -72,9 +72,22 @@ export async function attemptKbAutoReply(
   if (!conversation) return false;
 
   // 3. Channel botMode gating + 解析完整 botConfig（含 handoff prompt 設定）
+  // spread 對 undefined 才 fallback；空字串 / 不合法 enum 會覆蓋預設，需另外清理。
   const channelSettings = (conversation.channel.settings || {}) as Record<string, unknown>;
   const rawBotConfig = (channelSettings.botConfig || {}) as Partial<BotConfig>;
-  const botConfig: BotConfig = { ...DEFAULT_BOT_CONFIG, ...rawBotConfig };
+  const merged: BotConfig = { ...DEFAULT_BOT_CONFIG, ...rawBotConfig };
+  const botConfig: BotConfig = {
+    ...merged,
+    handoffPromptStyle: (['text', 'button', 'both', 'none'] as const).includes(
+      merged.handoffPromptStyle,
+    )
+      ? merged.handoffPromptStyle
+      : DEFAULT_BOT_CONFIG.handoffPromptStyle,
+    handoffButtonLabel:
+      typeof merged.handoffButtonLabel === 'string' && merged.handoffButtonLabel.trim().length > 0
+        ? merged.handoffButtonLabel
+        : DEFAULT_BOT_CONFIG.handoffButtonLabel,
+  };
   if (botConfig.botMode === 'off' || botConfig.botMode === 'keyword') return false;
 
   // 4. Load tenant chat settings (clarify thresholds + system prompts)
@@ -159,13 +172,7 @@ export async function attemptKbAutoReply(
   }
 
   // 8b. 決定要不要附 handoff prompt（只在 kb_with_handoff，kb_high_confidence 不附）
-  const kbReply = buildKbReplyPayload({
-    replyText,
-    replyKind,
-    botConfig,
-    articleId: topResult?.id,
-    botMessageId: null, // 先佔位，存完 message 後再補
-  });
+  const kbReply = buildKbReplyPayload({ replyText, replyKind, botConfig });
   // 真正送 channel 的文字（可能多帶 text suffix）— DB 也存這份以利客服 UI 對齊
   const finalText = kbReply.text;
 
@@ -266,8 +273,6 @@ function buildKbReplyPayload(input: {
   replyText: string;
   replyKind: ReplyKind;
   botConfig: BotConfig;
-  articleId: string | undefined;
-  botMessageId: string | null;
 }): { text: string; includeHandoffButton: boolean } {
   const { replyText, replyKind, botConfig } = input;
 

--- a/apps/api/src/modules/ai/kb-autoreply.service.ts
+++ b/apps/api/src/modules/ai/kb-autoreply.service.ts
@@ -22,10 +22,14 @@ import { getChatSettings } from '../settings/chat-settings.service.js';
 import { generateReply, CLARIFY_SYSTEM_PROMPT } from './llm.service.js';
 import type { HistoryMessage } from './llm.service.js';
 import { deliverToChannel } from '../conversation/conversation.service.js';
-import { hasMatchingKeywordRule } from '../automation/automation.worker.js';
+import {
+  hasMatchingKeywordRule,
+  DEFAULT_BOT_CONFIG,
+  DEFAULT_HANDOFF_PROMPT_TEXT,
+  type BotConfig,
+} from '../automation/automation.worker.js';
 import { logger } from '@open333crm/core';
 
-const HANDOFF_PROMPT = '需要真人客服協助嗎？請輸入「真人」或「客服」即可轉接。';
 const CLARIFY_HANDOFF_FALLBACK =
   '不好意思我這邊還沒辦法判斷您的需求，已為您轉接客服人員，請稍候。';
 const HISTORY_LIMIT = 10;
@@ -67,10 +71,11 @@ export async function attemptKbAutoReply(
   });
   if (!conversation) return false;
 
-  // 3. Channel botMode gating
+  // 3. Channel botMode gating + 解析完整 botConfig（含 handoff prompt 設定）
   const channelSettings = (conversation.channel.settings || {}) as Record<string, unknown>;
-  const botMode = channelSettings.botMode as string | undefined;
-  if (botMode === 'off' || botMode === 'keyword') return false;
+  const rawBotConfig = (channelSettings.botConfig || {}) as Partial<BotConfig>;
+  const botConfig: BotConfig = { ...DEFAULT_BOT_CONFIG, ...rawBotConfig };
+  if (botConfig.botMode === 'off' || botConfig.botMode === 'keyword') return false;
 
   // 4. Load tenant chat settings (clarify thresholds + system prompts)
   const chatSettings = await getChatSettings(prisma, tenantId);
@@ -141,24 +146,28 @@ export async function attemptKbAutoReply(
 
     try {
       const llmReply = await generateReply(prisma, tenantId, messageText, kbContext, { history });
-      if (topSimilarity >= 0.80) {
-        replyText = llmReply;
-        replyKind = 'kb_high_confidence';
-      } else {
-        replyText = `${llmReply}\n\n${HANDOFF_PROMPT}`;
-        replyKind = 'kb_with_handoff';
-      }
+      replyText = llmReply;
+      replyKind = topSimilarity >= 0.80 ? 'kb_high_confidence' : 'kb_with_handoff';
       // Successful KB answer resets clarify attempts
       metadataExtras = { clarifyAttempts: 0 };
     } catch (err) {
       logger.error('[KbAutoReply] LLM generation failed, falling back to article content:', err);
-      const fallbackText = topResult.content || topResult.summary || topResult.title;
-      replyText =
-        topSimilarity >= 0.80 ? fallbackText : `${fallbackText}\n\n${HANDOFF_PROMPT}`;
+      replyText = topResult.content || topResult.summary || topResult.title;
       replyKind = topSimilarity >= 0.80 ? 'kb_high_confidence' : 'kb_with_handoff';
       metadataExtras = { clarifyAttempts: 0 };
     }
   }
+
+  // 8b. 決定要不要附 handoff prompt（只在 kb_with_handoff，kb_high_confidence 不附）
+  const kbReply = buildKbReplyPayload({
+    replyText,
+    replyKind,
+    botConfig,
+    articleId: topResult?.id,
+    botMessageId: null, // 先佔位，存完 message 後再補
+  });
+  // 真正送 channel 的文字（可能多帶 text suffix）— DB 也存這份以利客服 UI 對齊
+  const finalText = kbReply.text;
 
   // 9. Persist BOT message
   const now = new Date();
@@ -168,7 +177,7 @@ export async function attemptKbAutoReply(
       direction: 'OUTBOUND',
       senderType: 'BOT',
       contentType: 'text',
-      content: { text: replyText },
+      content: { text: finalText },
       metadata: {
         source: 'kb_auto_reply',
         replyKind,
@@ -201,7 +210,7 @@ export async function attemptKbAutoReply(
       direction: 'OUTBOUND',
       senderType: 'BOT',
       contentType: 'text',
-      content: { text: replyText },
+      content: { text: finalText },
       metadata: botMessage.metadata,
       createdAt: now.toISOString(),
       sender: null,
@@ -212,30 +221,70 @@ export async function attemptKbAutoReply(
 
   // 12. Deliver to actual channel
   // 命中 KB 的回答附「👎 沒幫到我」回報按鈕（quick reply postback），供調教 KB。
-  // clarify / clarify_handoff 那種沒命中 KB 的不附（沒對應文章可回報）。
+  // 加上 handoff_request 按鈕（依 botConfig.handoffPromptStyle）給使用者一鍵轉接。
+  // clarify / clarify_handoff 那種沒命中 KB 的不附（沒對應文章可回報、也不附轉接按鈕）。
   const hitKb = replyKind === 'kb_high_confidence' || replyKind === 'kb_with_handoff';
+  const quickReplies: Array<{ label: string; postbackData: string }> = [];
   if (hitKb && topResult?.id) {
+    quickReplies.push({
+      label: '👎 沒幫到我',
+      postbackData: `kb_feedback:bad:${topResult.id}:${botMessage.id}`,
+    });
+  }
+  if (kbReply.includeHandoffButton) {
+    quickReplies.push({
+      label: botConfig.handoffButtonLabel,
+      postbackData: 'handoff_request',
+    });
+  }
+
+  if (quickReplies.length > 0) {
     await deliverToChannel(prisma, conversationId, {
       contentType: 'text',
-      content: {
-        text: replyText,
-        quickReplies: [
-          {
-            label: '👎 沒幫到我',
-            postbackData: `kb_feedback:bad:${topResult.id}:${botMessage.id}`,
-          },
-        ],
-      },
+      content: { text: finalText, quickReplies },
     });
   } else {
-    await deliverToChannel(prisma, conversationId, replyText);
+    await deliverToChannel(prisma, conversationId, finalText);
   }
 
   logger.info(
-    `[KbAutoReply] conv=${conversationId} kind=${replyKind} sim=${topSimilarity.toFixed(3)}`,
+    `[KbAutoReply] conv=${conversationId} kind=${replyKind} sim=${topSimilarity.toFixed(3)} handoffStyle=${botConfig.handoffPromptEnabled ? botConfig.handoffPromptStyle : 'disabled'}`,
   );
 
   return true;
+}
+
+/**
+ * 依 botConfig.handoffPromptEnabled / handoffPromptStyle 決定 KB 回答要不要附
+ * handoff 提示（文字 suffix 或 quick reply 按鈕）。
+ *
+ * - kb_high_confidence：不附（無論 botConfig 設定如何，高信心回答本身已足夠）
+ * - kb_with_handoff + enabled=true：依 style 決定（text / button / both / none）
+ * - enabled=false：完全不附
+ */
+function buildKbReplyPayload(input: {
+  replyText: string;
+  replyKind: ReplyKind;
+  botConfig: BotConfig;
+  articleId: string | undefined;
+  botMessageId: string | null;
+}): { text: string; includeHandoffButton: boolean } {
+  const { replyText, replyKind, botConfig } = input;
+
+  if (replyKind !== 'kb_with_handoff') {
+    return { text: replyText, includeHandoffButton: false };
+  }
+  if (!botConfig.handoffPromptEnabled) {
+    return { text: replyText, includeHandoffButton: false };
+  }
+
+  const style = botConfig.handoffPromptStyle;
+  const wantsText = style === 'text' || style === 'both';
+  const wantsButton = style === 'button' || style === 'both';
+  const text = wantsText
+    ? `${replyText}\n\n${DEFAULT_HANDOFF_PROMPT_TEXT}`
+    : replyText;
+  return { text, includeHandoffButton: wantsButton };
 }
 
 /**

--- a/apps/api/src/modules/automation/automation.worker.ts
+++ b/apps/api/src/modules/automation/automation.worker.ts
@@ -30,19 +30,30 @@ function automationQueue(): Queue {
   return _automationQueue;
 }
 
-interface BotConfig {
+export type HandoffPromptStyle = 'text' | 'button' | 'both' | 'none';
+
+export interface BotConfig {
   botMode: 'keyword' | 'llm' | 'keyword_then_llm' | 'off';
   maxBotReplies: number;
   handoffKeywords: string[];
   handoffMessage: string;
   offlineGreeting?: string;
+  handoffPromptEnabled: boolean;
+  handoffPromptStyle: HandoffPromptStyle;
+  handoffButtonLabel: string;
 }
 
-const DEFAULT_BOT_CONFIG: BotConfig = {
+export const DEFAULT_HANDOFF_PROMPT_TEXT =
+  '需要真人客服協助嗎？請輸入「真人」或「客服」即可轉接。';
+
+export const DEFAULT_BOT_CONFIG: BotConfig = {
   botMode: 'keyword_then_llm',
   maxBotReplies: 5,
   handoffKeywords: ['真人', '人工', '客服', '轉接'],
   handoffMessage: '稍等，正在為您轉接客服人員',
+  handoffPromptEnabled: true,
+  handoffPromptStyle: 'button',
+  handoffButtonLabel: '💬 轉接客服',
 };
 
 async function checkAutoHandoff(

--- a/apps/api/src/modules/webhook/webhook.service.ts
+++ b/apps/api/src/modules/webhook/webhook.service.ts
@@ -404,6 +404,55 @@ export async function processInboundMessage(
     return; // 不發 message.received，不觸發 automation（同 CSAT）
   }
 
+  // 5c. Intercept handoff_request postback — 使用者按「💬 轉接客服」一鍵轉真人
+  // 仿 CSAT / kb_feedback 攔截模式：不發 message.received、不觸發 automation
+  const handoffPattern = /^handoff_request$/i;
+  if (handoffPattern.test(postbackData) || handoffPattern.test(textContent)) {
+    try {
+      const fullChannel = await prisma.channel.findFirst({
+        where: { id: channel.id },
+        select: { settings: true },
+      });
+      const channelSettings = (fullChannel?.settings || {}) as Record<string, unknown>;
+      const botConfig = (channelSettings.botConfig || {}) as Record<string, unknown>;
+      const handoffMessage =
+        (botConfig.handoffMessage as string | undefined) || '稍等，正在為您轉接客服人員';
+
+      if (conversation.status === 'AGENT_HANDLED') {
+        // 冪等：已是 AGENT_HANDLED，只回訊息、不改狀態、不重發 event
+        await deliverToChannel(prisma, conversation.id, handoffMessage);
+        logger.info('[Webhook] handoff_request on AGENT_HANDLED conv (idempotent)', {
+          conversationId: conversation.id,
+        });
+      } else if (conversation.status === 'BOT_HANDLED') {
+        await prisma.conversation.update({
+          where: { id: conversation.id },
+          data: {
+            status: 'AGENT_HANDLED',
+            handoffReason: 'user_requested_handoff',
+          },
+        });
+        await deliverToChannel(prisma, conversation.id, handoffMessage);
+        eventBus.publish({
+          name: 'conversation.handoff',
+          tenantId,
+          timestamp: new Date(),
+          payload: {
+            conversationId: conversation.id,
+            reason: 'user_requested_handoff',
+            previousStatus: 'BOT_HANDLED',
+          },
+        });
+        logger.info('[Webhook] handoff_request → AGENT_HANDLED', {
+          conversationId: conversation.id,
+        });
+      }
+    } catch (err) {
+      logger.error('[Webhook] handoff_request handling failed:', err);
+    }
+    return; // 不發 message.received
+  }
+
   // 6. Track broadcast reply (non-blocking)
   trackBroadcastReply(prisma, contactId).catch(() => {});
 

--- a/apps/api/src/modules/webhook/webhook.service.ts
+++ b/apps/api/src/modules/webhook/webhook.service.ts
@@ -425,26 +425,80 @@ export async function processInboundMessage(
           conversationId: conversation.id,
         });
       } else if (conversation.status === 'BOT_HANDLED') {
-        await prisma.conversation.update({
+        const reason = 'user_requested_handoff';
+        // 寫 SYSTEM message 留軌跡（仿 automation.worker checkAutoHandoff）
+        const systemMessage = await prisma.message.create({
+          data: {
+            conversationId: conversation.id,
+            direction: 'OUTBOUND',
+            senderType: 'SYSTEM',
+            contentType: 'system',
+            content: { text: '使用者主動點按按鈕轉接人工客服' },
+            metadata: { type: 'user_requested_handoff', reason },
+            isRead: true,
+            createdAt: new Date(),
+          },
+        });
+
+        const updatedConversation = await prisma.conversation.update({
           where: { id: conversation.id },
           data: {
             status: 'AGENT_HANDLED',
-            handoffReason: 'user_requested_handoff',
+            handoffReason: reason,
+            lastMessageAt: new Date(),
           },
         });
+
         await deliverToChannel(prisma, conversation.id, handoffMessage);
+
         eventBus.publish({
           name: 'conversation.handoff',
           tenantId,
           timestamp: new Date(),
           payload: {
             conversationId: conversation.id,
-            reason: 'user_requested_handoff',
+            reason,
             previousStatus: 'BOT_HANDLED',
           },
         });
+
+        // Emit conversation.updated 讓客服 UI 即時看到狀態切換 + unreadCount 修正
+        const convPayload: ConversationUpdatedPayload = {
+          id: updatedConversation.id,
+          status: updatedConversation.status,
+          assignedToId: updatedConversation.assignedToId,
+          unreadCount: updatedConversation.unreadCount,
+          lastMessageAt: updatedConversation.lastMessageAt?.toISOString() ?? null,
+          updatedAt: updatedConversation.updatedAt.toISOString(),
+          handoffReason: reason,
+        };
+        io.to(`conversation:${conversation.id}`).emit('conversation.updated', convPayload);
+        io.to(`tenant:${tenantId}`).emit('conversation.updated', convPayload);
+
+        // Emit SYSTEM message 給客服 UI 看
+        io.to(`conversation:${conversation.id}`).emit('message.new', {
+          conversationId: conversation.id,
+          message: {
+            id: systemMessage.id,
+            conversationId: conversation.id,
+            direction: 'OUTBOUND',
+            senderType: 'SYSTEM',
+            contentType: 'system',
+            content: systemMessage.content,
+            metadata: systemMessage.metadata,
+            createdAt: systemMessage.createdAt.toISOString(),
+            sender: null,
+          },
+        });
+
         logger.info('[Webhook] handoff_request → AGENT_HANDLED', {
           conversationId: conversation.id,
+        });
+      } else {
+        // CLOSED / RESOLVED 或其他狀態：不接、靜默 log 警告
+        logger.warn('[Webhook] handoff_request ignored (unexpected status)', {
+          conversationId: conversation.id,
+          status: conversation.status,
         });
       }
     } catch (err) {

--- a/apps/web/src/components/settings/BotConfigForm.tsx
+++ b/apps/web/src/components/settings/BotConfigForm.tsx
@@ -15,13 +15,29 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 
+type HandoffPromptStyle = 'text' | 'button' | 'both' | 'none';
+
 interface BotConfig {
   botMode: string;
   maxBotReplies: number;
   handoffKeywords: string[];
   handoffMessage: string;
   offlineGreeting?: string;
+  handoffPromptEnabled: boolean;
+  handoffPromptStyle: HandoffPromptStyle;
+  handoffButtonLabel: string;
 }
+
+const DEFAULT_HANDOFF_PROMPT_ENABLED = true;
+const DEFAULT_HANDOFF_PROMPT_STYLE: HandoffPromptStyle = 'button';
+const DEFAULT_HANDOFF_BUTTON_LABEL = '💬 轉接客服';
+
+const handoffPromptStyleOptions = [
+  { value: 'button', label: '快速回覆按鈕（推薦）' },
+  { value: 'text', label: '純文字提示' },
+  { value: 'both', label: '兩者都要（文字 + 按鈕）' },
+  { value: 'none', label: '關閉（不顯示提示）' },
+];
 
 interface BotConfigFormProps {
   open: boolean;
@@ -49,6 +65,10 @@ export function BotConfigForm({ open, onOpenChange, channel, onSaved }: BotConfi
   const [handoffMessage, setHandoffMessage] = useState('稍等，正在為您轉接客服人員');
   const [offlineGreeting, setOfflineGreeting] = useState('');
   const [newKeyword, setNewKeyword] = useState('');
+  const [handoffPromptEnabled, setHandoffPromptEnabled] = useState(DEFAULT_HANDOFF_PROMPT_ENABLED);
+  const [handoffPromptStyle, setHandoffPromptStyle] =
+    useState<HandoffPromptStyle>(DEFAULT_HANDOFF_PROMPT_STYLE);
+  const [handoffButtonLabel, setHandoffButtonLabel] = useState(DEFAULT_HANDOFF_BUTTON_LABEL);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -61,6 +81,9 @@ export function BotConfigForm({ open, onOpenChange, channel, onSaved }: BotConfi
         setHandoffKeywords(bc.handoffKeywords ?? ['真人', '人工', '客服', '轉接']);
         setHandoffMessage(bc.handoffMessage ?? '稍等，正在為您轉接客服人員');
         setOfflineGreeting(bc.offlineGreeting ?? '');
+        setHandoffPromptEnabled(bc.handoffPromptEnabled ?? DEFAULT_HANDOFF_PROMPT_ENABLED);
+        setHandoffPromptStyle(bc.handoffPromptStyle ?? DEFAULT_HANDOFF_PROMPT_STYLE);
+        setHandoffButtonLabel(bc.handoffButtonLabel ?? DEFAULT_HANDOFF_BUTTON_LABEL);
       } else {
         // Reset to defaults
         setBotMode('keyword_then_llm');
@@ -68,6 +91,9 @@ export function BotConfigForm({ open, onOpenChange, channel, onSaved }: BotConfi
         setHandoffKeywords(['真人', '人工', '客服', '轉接']);
         setHandoffMessage('稍等，正在為您轉接客服人員');
         setOfflineGreeting('');
+        setHandoffPromptEnabled(DEFAULT_HANDOFF_PROMPT_ENABLED);
+        setHandoffPromptStyle(DEFAULT_HANDOFF_PROMPT_STYLE);
+        setHandoffButtonLabel(DEFAULT_HANDOFF_BUTTON_LABEL);
       }
     }
     setError(null);
@@ -98,6 +124,9 @@ export function BotConfigForm({ open, onOpenChange, channel, onSaved }: BotConfi
         handoffKeywords,
         handoffMessage,
         offlineGreeting: offlineGreeting || undefined,
+        handoffPromptEnabled,
+        handoffPromptStyle,
+        handoffButtonLabel,
       };
 
       await api.patch(`/channels/${channel.id}`, {
@@ -199,6 +228,65 @@ export function BotConfigForm({ open, onOpenChange, channel, onSaved }: BotConfi
               placeholder="轉接時發送給客戶的訊息"
               rows={2}
             />
+          </div>
+
+          {/* Handoff Prompt (KB 回答後的轉接提示) */}
+          <div className="rounded-md border border-border bg-muted/30 p-3 space-y-3">
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium" htmlFor="handoffPromptEnabled">
+                轉接真人提示
+              </label>
+              <label className="inline-flex items-center gap-2 text-sm cursor-pointer">
+                <input
+                  id="handoffPromptEnabled"
+                  type="checkbox"
+                  className="h-4 w-4"
+                  checked={handoffPromptEnabled}
+                  onChange={(e) => setHandoffPromptEnabled(e.target.checked)}
+                />
+                <span>{handoffPromptEnabled ? '已開啟' : '已關閉'}</span>
+              </label>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              KB 中等信心回答（命中但不確定）下方是否提示可轉接真人
+            </p>
+
+            {handoffPromptEnabled && (
+              <>
+                <div>
+                  <label className="mb-1.5 block text-sm font-medium">提示方式</label>
+                  <Select
+                    value={handoffPromptStyle}
+                    onChange={(e) => setHandoffPromptStyle(e.target.value as HandoffPromptStyle)}
+                    options={handoffPromptStyleOptions}
+                  />
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {handoffPromptStyle === 'button'
+                      ? '回答下方顯示「轉接客服」快速回覆按鈕，使用者點按即轉接'
+                      : handoffPromptStyle === 'text'
+                      ? '回答尾部加一行「請輸入『真人』即可轉接」文字提示'
+                      : handoffPromptStyle === 'both'
+                      ? '同時顯示文字提示與快速回覆按鈕'
+                      : '不顯示任何提示。使用者仍可打「真人」「客服」等關鍵字觸發轉接'}
+                  </p>
+                </div>
+
+                {(handoffPromptStyle === 'button' || handoffPromptStyle === 'both') && (
+                  <div>
+                    <label className="mb-1.5 block text-sm font-medium">按鈕文字</label>
+                    <Input
+                      value={handoffButtonLabel}
+                      onChange={(e) => setHandoffButtonLabel(e.target.value)}
+                      placeholder="💬 轉接客服"
+                      maxLength={20}
+                    />
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      LINE quick reply label 上限 20 字
+                    </p>
+                  </div>
+                )}
+              </>
+            )}
           </div>
 
           {/* Offline Greeting */}

--- a/apps/web/src/components/settings/BotConfigForm.tsx
+++ b/apps/web/src/components/settings/BotConfigForm.tsx
@@ -118,6 +118,8 @@ export function BotConfigForm({ open, onOpenChange, channel, onSaved }: BotConfi
 
     try {
       const existingSettings = (channel.settings || {}) as Record<string, unknown>;
+      // 空字串會在後端 spread 覆蓋掉預設值 → LINE quick reply label 不可為空，trim 後若空就 fallback
+      const trimmedLabel = handoffButtonLabel.trim();
       const botConfig: BotConfig = {
         botMode,
         maxBotReplies,
@@ -126,7 +128,7 @@ export function BotConfigForm({ open, onOpenChange, channel, onSaved }: BotConfi
         offlineGreeting: offlineGreeting || undefined,
         handoffPromptEnabled,
         handoffPromptStyle,
-        handoffButtonLabel,
+        handoffButtonLabel: trimmedLabel || DEFAULT_HANDOFF_BUTTON_LABEL,
       };
 
       await api.patch(`/channels/${channel.id}`, {

--- a/openspec/changes/handoff-prompt-configurable/.openspec.yaml
+++ b/openspec/changes/handoff-prompt-configurable/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-01

--- a/openspec/changes/handoff-prompt-configurable/design.md
+++ b/openspec/changes/handoff-prompt-configurable/design.md
@@ -1,0 +1,123 @@
+## Context
+
+`apps/api/src/modules/ai/kb-autoreply.service.ts:28` 有一個寫死的常數：
+```ts
+const HANDOFF_PROMPT = '需要真人客服協助嗎？請輸入「真人」或「客服」即可轉接。';
+```
+
+當 KB 比對到中等信心（similarity 0.5 ~ 0.8）的文章時（line 148/157），系統會把這段文字接在 LLM 生成回答的尾巴：
+```ts
+replyText = `${llmReply}\n\n${HANDOFF_PROMPT}`;
+```
+
+目前的「真人轉接」全靠關鍵字（`handoffKeywords` 預設 `['真人', '人工', '客服', '轉接']`），在 `apps/api/src/modules/automation/automation.worker.ts` 的 `checkAutoHandoff` 偵測使用者訊息字串。如果用戶不打這些字，就沒辦法轉接 — 文字提示本質上是「告訴用戶該打什麼」。
+
+對老人家、長輩使用者來說，打字困難。從這次 LINE 對話截圖看到的問題：
+1. KB 回答尾巴每句都有「請輸入...真人」一大段，視覺很冗
+2. 有時 LLM 自己模仿（system prompt 內也提到「真人」），加 code 又串一份，同句出現兩次
+3. 後台改不了 — 要改文案、要關掉、要按頻道差異化都得改 code
+
+`Channel.settings.botConfig` 已存在類似可設定欄位（`handoffMessage`、`handoffKeywords`、`offlineGreeting`、`maxBotReplies`、`botMode`），這次直接擴充同一個 JSON、不動 schema。`BotConfigForm.tsx` 已有對應前端 UI，加 3 個欄位即可。
+
+另一個既有設計範本：「👎 沒幫到我」回報按鈕（PR #125 剛完成）也是 quick reply postback + webhook 攔截 + 不觸發 automation 的模式，本次新功能完全可仿照。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 把 KB 回答尾巴的「需要真人客服協助嗎...」從寫死常數改為 `Channel.settings.botConfig` 內可設定
+- 預設改用 quick reply 按鈕（一鍵點），減少老人家打字負擔
+- 後台 `BotConfigForm` 可開關/換樣式/改按鈕文字
+- 與既有「👎 沒幫到我」postback 機制保持一致（同樣的 webhook 攔截模式）
+- 保留既有 `handoffKeywords` 路徑（用戶打字仍可轉接，舊有 muscle memory 不壞）
+
+**Non-Goals:**
+- 不改 LLM system prompt 內容（如果 LLM 自己生成「請輸入真人」、本 change 不負責修，是 prompt tuning 議題）
+- 不改 `handoffMessage` 預設值（轉接成功後 bot 回的訊息）
+- 不做「按 contact tier 動態決定 prompt 樣式」（一律走 channel 級設定）
+- 不對 FB / WEBCHAT 做特殊處理（這次焦點是 LINE，但設計保留通用性 — quick reply 在 LINE 是按鈕、其他 channel 可能用 quick_reply contentType）
+- 不改 prisma schema（沿用 Channel.settings JSON）
+
+## Decisions
+
+### 1. 設定存哪裡：`Channel.settings.botConfig` JSON
+**選**：擴充既有 `botConfig` JSON、加 3 個欄位
+**沒選**：新建 prisma 表 / 加 Channel 欄位
+
+**理由**：
+- botConfig 本來就是「bot 行為設定」的集中地（已有 botMode / handoffKeywords / handoffMessage / offlineGreeting / maxBotReplies），新欄位語意完全相容
+- 無 migration、向後相容（既有 channel 缺欄位就走預設）
+- 後台 BotConfigForm 已存在，加 UI 即可
+
+### 2. 預設樣式：`button`（quick reply 按鈕）
+**選**：預設 `handoffPromptStyle = 'button'`
+**沒選**：預設 `'text'`（維持現狀）
+
+**理由**：
+- 老人家打字難、按鈕點一下就轉接是更好的 UX
+- quick reply 已有現成 payload 結構（PR #125 quick reply preset / kb_feedback 都用同樣機制）
+- 預設改變雖然是 behavioral change，但老的「請輸入真人」幫助不大、改了就改了
+
+**取捨**：對已習慣「打真人」轉接的老用戶可能有一瞬不適應，但 `handoffKeywords` 仍存在 → 打字也仍會轉接。
+
+### 3. Postback 命名：`handoff_request`
+**選**：`handoff_request`（無 articleId / 無 conversationId）
+**沒選**：`handoff:{conversationId}` 之類帶 ID
+
+**理由**：
+- 從 webhook 進來時已有 `conversation` 變數可用（PR #125 kb_feedback 攔截已驗證），不需從 postback data 反查
+- 簡單、容易在 regex 一行 match：`/^handoff_request$/`
+- 與 `kb_feedback:bad:...` / `csat:N:UUID` 同樣 prefix-based 風格
+
+### 4. 轉接後行為：直接設 AGENT_HANDLED + 通知 SUPERVISOR
+**選**：webhook 攔截 → `prisma.conversation.update({ status: 'AGENT_HANDLED' })` + bot 回 `handoffMessage` + 透過 eventBus 發 `conversation.handoff` 事件給 supervisor
+**沒選**：把人工接手延後到第一個 supervisor 真的看到/接
+
+**理由**：
+- 與既有「使用者打『真人』關鍵字」的處理對齊（`checkAutoHandoff` 已做這事）
+- 直接改狀態 = bot 停止介入、客服收到通知後可主動回覆
+- 既有 `conversation.handoff` event 已有 notification.worker 訂閱者通知 supervisor
+
+### 5. 提示樣式 4 選項：text / button / both / none
+**選**：四值列舉
+**沒選**：只兩值（on / off）
+
+**理由**：
+- `text`：保留舊行為（給已習慣的客戶）
+- `button`：新預設（推薦）
+- `both`：過渡期可用（文字 + 按鈕雙保險）
+- `none`：完全關掉提示（用戶要轉接得自己打關鍵字）
+
+### 6. 不動 LLM system prompt
+**範圍切割**：本 change 只負責「code 串接的提示文字」這部分。LLM 自己生成的「請輸入真人」是 prompt engineering 議題（chat-settings 內可改），不在這次範圍。
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| 預設改 `button` 是 behavioral change，老用戶 LINE 端突然看到按鈕可能困惑 | 按鈕文字明確「💬 轉接客服」即可。且 `handoffKeywords` 仍生效、打字仍會轉接 |
+| LLM 自己生成「請輸入真人」造成重複（不在本 change 範圍） | 文件註明 follow-up，建議改 chat-settings 預設 prompt 加 「不要主動建議用戶打真人/客服」 |
+| `handoff_request` postback 與 `csat:` / `kb_feedback:` 同樣靠 webhook 攔截，新 prefix 要避免與既有衝突 | `handoff_request` 全字嚴格匹配 `/^handoff_request$/`，前綴不撞 |
+| `none` 模式下，使用者只能靠 `handoffKeywords`，老人家可能找不到轉接方式 | `none` 是進階選項、不是預設；後台 UI 提示「關閉後使用者需主動打『真人』才能轉接」 |
+| Channel.settings JSON 加欄位無型別保護 — 寫錯欄位名 silent fallback 到預設 | `BotConfigForm` 是唯一寫入入口、UI 控制欄位名；BotConfig TS interface 集中定義 |
+| `handoffPromptEnabled=false` 但 `handoffPromptStyle` 仍設值 → 行為以哪個為準？ | code 內 `enabled=false` 短路、不看 style |
+
+## Migration Plan
+
+**部署步驟**：純 application code 改動
+1. Merge PR 到 main
+2. Louis 部署 UAT：`git pull` + `docker compose up -d --build`（rebuild containers）
+3. **不需** `prisma migrate deploy`（無 schema 變更）
+4. **不需** 對既有 Channel 資料做 backfill — 缺欄位 fallback 預設
+
+**Rollback**：直接 revert PR 即可。Channel.settings 內多出來的欄位無害（被忽略）。
+
+**驗證**（部署後）：
+- 後台 BotConfigForm 應出現「轉接真人提示」3 個新設定
+- LINE 對話：KB 中等信心回答後應出現「💬 轉接客服」quick reply 按鈕
+- 點按鈕 → bot 回 handoffMessage（例如「稍等，正在為您轉接客服人員」）→ DB conversation status 變 AGENT_HANDLED → SUPERVISOR 收到通知
+- 改 botConfig 設 `handoffPromptStyle: 'none'` → 後續 KB 回答不再有提示
+
+## Open Questions
+
+- LLM system prompt 是否也要改？（建議另開 follow-up，非本 change 範圍）
+- `both` 模式（文字 + 按鈕）是否實用？（保留選項，看後續使用率決定要不要砍）

--- a/openspec/changes/handoff-prompt-configurable/proposal.md
+++ b/openspec/changes/handoff-prompt-configurable/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+目前 LINE bot KB 自動回覆會在「中等信心」（KB similarity 0.5 ~ 0.8）的回答尾巴硬接一段文字：「需要真人客服協助嗎？請輸入「真人」或「客服」即可轉接。」（`HANDOFF_PROMPT` 常數，寫死在 `apps/api/src/modules/ai/kb-autoreply.service.ts:28`）。實際使用上有三個問題：
+
+1. **不可由後台設定**：要改文案、要關掉、要換 channel 設定都得改 code 重部署
+2. **使用者體驗差**：每句訊息結尾都有這段「請輸入...」很冗長，老人家根本不會打字觸發
+3. **常被 LLM 重複生成**：system prompt 也提到「需要真人客服...」，LLM 學樣回覆，加上 code 又串一份，同句出現兩次
+
+合理改進：把這段提示變成可設定（文字 / 快速回覆按鈕 / 關閉），預設改用 quick reply 按鈕（用戶一鍵點即可），與既有「👎 沒幫到我」回報按鈕同模式。
+
+## What Changes
+
+- 在 `Channel.settings.botConfig` 加 3 個欄位（後台可改、無需 schema migration）：
+  - `handoffPromptEnabled` (boolean, 預設 `true`)：是否在 KB 回答附 handoff 提示
+  - `handoffPromptStyle` (`'text' | 'button' | 'both' | 'none'`, 預設 `'button'`)：提示形式
+  - `handoffButtonLabel` (string, 預設 `'💬 轉接客服'`)：按鈕文字
+- `kb-autoreply.service.ts` 讀 `botConfig` 決定要不要串文字 / 加 quick reply 按鈕，**移除硬寫的 `HANDOFF_PROMPT`**（改成 botConfig 預設值）
+- `webhook.service.ts` 攔截新 postback `handoff_request` → 設 conversation `AGENT_HANDLED` + 回確認訊息 + 通知所有 SUPERVISOR/ADMIN（仿照既有 `kb_feedback` 攔截模式）
+- `BotConfigForm.tsx` 加對應 UI（開關 + style 選項 + 按鈕文字 input）
+- 既有的關鍵字轉接（`handoffKeywords`）路徑**保留不變**（使用者打「真人」「客服」「轉接」仍可手動觸發）
+
+## Capabilities
+
+### New Capabilities
+- `bot-handoff-config`: bot 自動回覆轉接真人客服的提示設定（什麼時候提示、用什麼形式提示、按鈕點擊後的處理流程）
+
+### Modified Capabilities
+（無 — 既有 spec 中沒有定義過 KB auto-reply 的 handoff prompt 行為，這是新增 capability）
+
+## Impact
+
+**程式碼**
+- 後端：`apps/api/src/modules/ai/kb-autoreply.service.ts`（移除硬寫常數、讀 botConfig）、`apps/api/src/modules/webhook/webhook.service.ts`（加新 postback 攔截）、`apps/api/src/modules/automation/automation.worker.ts`（BotConfig interface 加 3 欄位 + DEFAULT_BOT_CONFIG）
+- 前端：`apps/web/src/components/settings/BotConfigForm.tsx`（加 3 個設定 UI）
+
+**資料庫**：無 schema 變更（沿用 `Channel.settings` JSON 欄位、向後相容）
+
+**API**：無新 endpoint（沿用既有 channel settings 更新路徑）
+
+**外部依賴**：無
+
+**部署影響**：純 application code 改動，部署只需 rebuild containers、不需跑 migration。既有 channel 若無設定值，會 fallback 到新預設（`button` 模式 + `💬 轉接客服` 文字），行為改變但不會壞。
+
+**相容性**：保留既有 `handoffKeywords` 觸發路徑，使用者打「真人」「客服」仍會轉接；只是視覺上多/少了 KB 回答後面的提示。

--- a/openspec/changes/handoff-prompt-configurable/specs/bot-handoff-config/spec.md
+++ b/openspec/changes/handoff-prompt-configurable/specs/bot-handoff-config/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Handoff prompt configurable per channel
+The system SHALL store the handoff-to-human prompt configuration in `Channel.settings.botConfig` JSON with three fields: `handoffPromptEnabled` (boolean, default `true`), `handoffPromptStyle` (`'text' | 'button' | 'both' | 'none'`, default `'button'`), and `handoffButtonLabel` (string, default `'💬 轉接客服'`).
+
+#### Scenario: Channel without botConfig fields
+- **WHEN** a Channel has no `handoffPromptEnabled` / `handoffPromptStyle` / `handoffButtonLabel` in its `settings.botConfig`
+- **THEN** the system SHALL fall back to defaults `true` / `'button'` / `'💬 轉接客服'`
+
+#### Scenario: Admin updates botConfig via settings
+- **WHEN** an admin saves new `handoffPromptStyle: 'none'` via the channel settings UI
+- **THEN** the value is persisted to `Channel.settings.botConfig.handoffPromptStyle` and takes effect on the next inbound message
+
+### Requirement: KB auto-reply attaches handoff prompt per botConfig
+The system SHALL, when sending a KB auto-reply with reply kind `kb_with_handoff` (similarity between `clarifyThreshold` and `0.80`), read the channel's `botConfig.handoffPromptStyle` and attach the handoff prompt accordingly. The hardcoded `HANDOFF_PROMPT` constant in `kb-autoreply.service.ts` SHALL be removed; the default text used when style is `'text'` or `'both'` lives in the BotConfig defaults.
+
+#### Scenario: Style is button (default)
+- **WHEN** a KB auto-reply triggers with `kb_with_handoff` and `botConfig.handoffPromptStyle === 'button'`
+- **THEN** the outbound message SHALL NOT contain the handoff text and SHALL include a quick reply item with `label = handoffButtonLabel` and `postbackData = 'handoff_request'`
+
+#### Scenario: Style is text
+- **WHEN** a KB auto-reply triggers with `kb_with_handoff` and `botConfig.handoffPromptStyle === 'text'`
+- **THEN** the outbound message text SHALL be `<llmReply>\n\n<defaultHandoffPromptText>` and SHALL NOT include the handoff quick reply
+
+#### Scenario: Style is both
+- **WHEN** a KB auto-reply triggers with `kb_with_handoff` and `botConfig.handoffPromptStyle === 'both'`
+- **THEN** the outbound message SHALL include both the text suffix AND the quick reply button
+
+#### Scenario: Style is none
+- **WHEN** a KB auto-reply triggers with `kb_with_handoff` and `botConfig.handoffPromptStyle === 'none'`
+- **THEN** the outbound message SHALL contain only the LLM reply, no text suffix, no quick reply
+
+#### Scenario: Prompt disabled
+- **WHEN** `botConfig.handoffPromptEnabled === false`
+- **THEN** the outbound message SHALL contain only the LLM reply regardless of `handoffPromptStyle` value
+
+#### Scenario: KB high confidence reply (sim >= 0.80)
+- **WHEN** a KB auto-reply triggers with reply kind `kb_high_confidence`
+- **THEN** no handoff prompt SHALL be attached (button or text), regardless of botConfig — `kb_high_confidence` already represents a confident answer
+
+### Requirement: Webhook intercepts handoff_request postback
+The system SHALL intercept LINE postback events with data `handoff_request` in `webhook.service.ts` and treat them as an explicit user request to escalate to a human agent. The interception SHALL occur after CSAT and `kb_feedback` interception, and SHALL `return` early without publishing the `message.received` event (avoiding accidental automation re-triggers, same pattern as CSAT / kb_feedback).
+
+#### Scenario: User taps the handoff quick reply
+- **WHEN** the webhook receives a postback with `data === 'handoff_request'` on a conversation in `BOT_HANDLED` status
+- **THEN** the system SHALL update the conversation `status` to `'AGENT_HANDLED'` with `handoffReason: 'user_requested_handoff'`
+- **AND** the system SHALL send the channel `botConfig.handoffMessage` (default `'稍等，正在為您轉接客服人員'`) to the user
+- **AND** the system SHALL publish a `conversation.handoff` eventBus event so SUPERVISOR/ADMIN are notified
+- **AND** the system SHALL NOT publish `message.received` (no automation re-trigger)
+
+#### Scenario: handoff_request on already AGENT_HANDLED conversation
+- **WHEN** the webhook receives `handoff_request` on a conversation already in `AGENT_HANDLED` status
+- **THEN** the system SHALL idempotently respond with the handoffMessage (no DB status change) and SHALL NOT republish the handoff event
+
+### Requirement: BotConfig form exposes handoff prompt fields
+The system SHALL expose the three new botConfig fields in the admin `BotConfigForm.tsx` UI: a boolean toggle for `handoffPromptEnabled`, a radio group for `handoffPromptStyle` (4 options), and a text input for `handoffButtonLabel`. The UI SHALL display helper text explaining that when style is `'none'`, users can still trigger handoff by typing keywords (`handoffKeywords`).
+
+#### Scenario: Admin opens BotConfig settings
+- **WHEN** an admin opens a LINE channel's BotConfig dialog
+- **THEN** the UI SHALL display all three new fields with the channel's current values (or defaults if unset)
+
+#### Scenario: Admin saves with style = none
+- **WHEN** an admin sets `handoffPromptStyle: 'none'` and saves
+- **THEN** the UI SHALL show a hint that the user can still type `handoffKeywords` (`真人` / `客服` / ...) to trigger handoff
+
+### Requirement: Existing handoffKeywords path remains active
+The system SHALL retain the existing `handoffKeywords` detection logic in `checkAutoHandoff`. Users who type any configured keyword in `botConfig.handoffKeywords` SHALL be auto-handed off regardless of the new `handoffPromptEnabled` / `handoffPromptStyle` settings.
+
+#### Scenario: User types keyword while prompt is disabled
+- **WHEN** `handoffPromptEnabled === false` (no prompt shown) and the user types `真人`
+- **THEN** the conversation SHALL still be auto-handed off via the existing `checkAutoHandoff` keyword path

--- a/openspec/changes/handoff-prompt-configurable/tasks.md
+++ b/openspec/changes/handoff-prompt-configurable/tasks.md
@@ -1,0 +1,54 @@
+## 1. Backend — BotConfig 擴充
+
+- [ ] 1.1 在 `apps/api/src/modules/automation/automation.worker.ts` 的 `BotConfig` interface 加 3 個欄位（`handoffPromptEnabled: boolean`、`handoffPromptStyle: 'text' | 'button' | 'both' | 'none'`、`handoffButtonLabel: string`）
+- [ ] 1.2 `DEFAULT_BOT_CONFIG` 加對應預設值（`true` / `'button'` / `'💬 轉接客服'`）+ 新增 `DEFAULT_HANDOFF_PROMPT_TEXT` 常數（保留現有「需要真人客服協助嗎？...」文字當預設）
+- [ ] 1.3 export `DEFAULT_HANDOFF_PROMPT_TEXT` 與 `BotConfig` type 供 kb-autoreply 使用
+
+## 2. Backend — kb-autoreply 讀 botConfig
+
+- [ ] 2.1 `apps/api/src/modules/ai/kb-autoreply.service.ts` 移除 `HANDOFF_PROMPT` 常數
+- [ ] 2.2 在 `attemptKbAutoReply` 內取出 `conversation.channel.settings.botConfig`、合併預設後得到完整 `botConfig`
+- [ ] 2.3 改寫 line 148 / 157 區段：依 `botConfig.handoffPromptEnabled` + `handoffPromptStyle` 決定 replyText 是否串文字（`text` / `both`）以及是否要在 deliverToChannel 帶 quick reply（`button` / `both`，postbackData = `'handoff_request'`、label = `botConfig.handoffButtonLabel`）
+- [ ] 2.4 `kb_high_confidence` 路徑明確不附 handoff prompt（即使 botConfig 開）
+- [ ] 2.5 在 `kb_high_confidence` 與 `kb_with_handoff` 兩條路徑共用一個 helper（如 `buildKbReplyPayload`）避免重複邏輯
+- [ ] 2.6 確認 deliverToChannel 傳遞時，與既有「👎 沒幫到我」quick reply 在同一則訊息時，quickReplies 陣列合併正確（兩個按鈕並存）
+
+## 3. Backend — webhook 攔截 handoff_request postback
+
+- [ ] 3.1 `apps/api/src/modules/webhook/webhook.service.ts` 在 CSAT (5.) 與 kb_feedback (5b.) 攔截後加新區塊 5c. 攔截 `postbackData === 'handoff_request'`
+- [ ] 3.2 取 `conversation.channel.settings.botConfig.handoffMessage`（已存在）作為回覆訊息（無設定 fallback 預設 `'稍等，正在為您轉接客服人員'`）
+- [ ] 3.3 若 conversation 已是 `AGENT_HANDLED`：只回 handoffMessage、不重複改狀態、不重發 event（冪等）
+- [ ] 3.4 若 conversation 是 `BOT_HANDLED`：`prisma.conversation.update({ status: 'AGENT_HANDLED', handoffReason: 'user_requested_handoff' })`、deliverToChannel(handoffMessage)、eventBus publish `conversation.handoff`（payload 含 conversationId / reason / previousStatus）
+- [ ] 3.5 `return` 跳過 message.received（仿照 CSAT / kb_feedback 模式）
+
+## 4. Frontend — BotConfigForm UI
+
+- [ ] 4.1 `apps/web/src/components/settings/BotConfigForm.tsx` 加 state：`handoffPromptEnabled`、`handoffPromptStyle`、`handoffButtonLabel`
+- [ ] 4.2 表單從 channel settings 載入時讀對應欄位（fallback 預設）、儲存時寫回 `botConfig.*`
+- [ ] 4.3 新增 UI 區塊「轉接真人提示」：
+  - Switch / checkbox：「在 KB 自動回覆下方提示可轉接真人」（綁 `handoffPromptEnabled`）
+  - Radio group：「提示方式」（4 選項：純文字 / 快速回覆按鈕 / 兩者都要 / 關閉）（綁 `handoffPromptStyle`）
+  - Text input：「按鈕文字」（綁 `handoffButtonLabel`，僅 `button`/`both` 時顯示）
+- [ ] 4.4 `style === 'none'` 時 UI 顯示提示：「使用者仍可打『真人/客服』等關鍵字觸發轉接」
+
+## 5. 驗證
+
+- [ ] 5.1 typecheck：`pnpm --filter @open333crm/api exec tsc --noEmit && pnpm --filter @open333crm/web exec tsc --noEmit`
+- [ ] 5.2 完整 build：`pnpm build`（12/12 packages 應全綠）
+- [ ] 5.3 本機 dev 驗證：
+  - 開 channel settings 看到 3 個新欄位、可儲存
+  - 模擬 KB 中等信心回答（設定 `'button'` 模式 → 看到 quick reply、`'none'` → 沒提示、`'text'` → 文字、`'both'` → 兩者都有）
+  - `handoffPromptEnabled: false` 時無論 style 為何都不附提示
+- [ ] 5.4 LINE 端實測（部署 UAT 後）：
+  - KB 命中 sim 0.5~0.8 訊息 → 看到「💬 轉接客服」quick reply
+  - 點按鈕 → 收到 `botConfig.handoffMessage` → conversation 變 AGENT_HANDLED → supervisor 收到通知
+  - 已是 AGENT_HANDLED 再點 → 不會重發 event（冪等）
+  - 改 botConfig style: 'none' 後重新對話 → 回答後面不再有提示
+  - 打「真人」關鍵字 → 仍正常轉接（既有 handoffKeywords 路徑保留）
+
+## 6. 部署
+
+- [ ] 6.1 commit + push feature branch + 開 PR
+- [ ] 6.2 PR 描述含 BotConfig 新欄位列表與 migration notes（無 schema 變更、無 backfill 需求）
+- [ ] 6.3 CI 過後 merge 到 main
+- [ ] 6.4 Louis 部署 UAT（rebuild containers、不需 prisma migrate deploy）


### PR DESCRIPTION
## Summary

- 將 `kb-autoreply.service.ts:28` 寫死的 `HANDOFF_PROMPT` 常數搬到 `Channel.settings.botConfig`，後台可調
- BotConfig 新增 3 欄位：`handoffPromptEnabled` (default `true`) / `handoffPromptStyle` (`'text' | 'button' | 'both' | 'none'`，default `'button'`) / `handoffButtonLabel` (default `'💬 轉接客服'`)
- 預設改用 **quick reply 按鈕**（postback `handoff_request`）— 老人家不用打字也能轉接
- 攔截 `handoff_request` postback（仿 CSAT / `kb_feedback`）：`BOT_HANDLED → AGENT_HANDLED` + 回 `handoffMessage` + publish `conversation.handoff` event；`AGENT_HANDLED` 冪等
- 既有 `handoffKeywords` 路徑保留 — 打字仍可轉接，舊用戶 muscle memory 不壞

## OpenSpec

依 `openspec/changes/handoff-prompt-configurable/` 實作（proposal + design + spec + tasks 完整）。

## Files changed

| 檔 | 動 |
|---|---|
| `apps/api/src/modules/automation/automation.worker.ts` | BotConfig interface + DEFAULT_BOT_CONFIG 加 3 欄位、export type/constants |
| `apps/api/src/modules/ai/kb-autoreply.service.ts` | 移除 HANDOFF_PROMPT 常數、加 `buildKbReplyPayload` helper、依 botConfig 決定 text/button |
| `apps/api/src/modules/webhook/webhook.service.ts` | 加 5c. handoff_request postback 攔截 |
| `apps/web/src/components/settings/BotConfigForm.tsx` | 加「轉接真人提示」UI 區塊（開關 + style select + 按鈕文字 input） |

## Migration notes

- **無 prisma schema 變更**（沿用 `Channel.settings` JSON）
- **無 backfill**（缺欄位 fallback 預設）
- 部署：`pnpm build` → Louis rebuild containers，不需 `prisma migrate deploy`

## Behavioral change

- KB 中等信心回答（`kb_with_handoff`，sim 0.5~0.8）的轉接提示**預設改為 quick reply 按鈕**
- 高信心回答（`kb_high_confidence`，sim ≥ 0.80）**永遠不附**轉接提示（無論 botConfig）

## Test plan

- [x] `pnpm --filter @open333crm/api exec tsc --noEmit` 過
- [x] `pnpm --filter @open333crm/web exec tsc --noEmit` 過
- [x] `pnpm build` 12/12 packages 過
- [ ] UAT 部署後 LINE 端實測：
  - [ ] 中信心 KB 回答下方出現「💬 轉接客服」quick reply
  - [ ] 點按鈕 → 收到 handoffMessage → conversation 變 AGENT_HANDLED → supervisor 收通知
  - [ ] 已 AGENT_HANDLED 再點 → 不會重發 event（冪等）
  - [ ] 改 style 為 `'none'` → 回答後面不再有提示
  - [ ] 打「真人」關鍵字 → 仍正常轉接

🤖 Generated with [Claude Code](https://claude.com/claude-code)