### PR TITLE
feat: AI 客服型號守門 — 查無型號時引導使用者選正確型號

### DIFF
--- a/apps/api/src/modules/ai/kb-autoreply.service.ts
+++ b/apps/api/src/modules/ai/kb-autoreply.service.ts
@@ -19,8 +19,10 @@ import { getConfig } from '../../config/env.js';
 import { generateEmbedding, searchSimilarArticles } from '../embedding/embedding.service.js';
 import { getEmbeddingSettings } from '../settings/embedding-settings.service.js';
 import { getChatSettings } from '../settings/chat-settings.service.js';
-import { generateReply, CLARIFY_SYSTEM_PROMPT } from './llm.service.js';
+import { generateReply, CLARIFY_SYSTEM_PROMPT, MODEL_GUIDE_SYSTEM_PROMPT } from './llm.service.js';
 import type { HistoryMessage } from './llm.service.js';
+import { detectModels, isKnownModel, findRelatedModels } from './model-matcher.js';
+import { getKnownModelKeys } from './model-registry.service.js';
 import { deliverToChannel } from '../conversation/conversation.service.js';
 import {
   hasMatchingKeywordRule,
@@ -34,7 +36,19 @@ const CLARIFY_HANDOFF_FALLBACK =
   '不好意思我這邊還沒辦法判斷您的需求，已為您轉接客服人員，請稍候。';
 const HISTORY_LIMIT = 10;
 
-type ReplyKind = 'kb_high_confidence' | 'kb_with_handoff' | 'clarify' | 'clarify_handoff';
+/**
+ * 型號守門「高相似度豁免」門檻。
+ * 客戶提到的型號雖不在白名單，但若 KB 相似度 >= 此值，視為「白名單可能慢半拍、
+ * 但 KB 其實有對應文章」，仍放行走正常 KB 回答，避免誤擋剛新增的型號。
+ */
+const MODEL_GUARD_EXEMPT_SIMILARITY = 0.85;
+
+type ReplyKind =
+  | 'kb_high_confidence'
+  | 'kb_with_handoff'
+  | 'clarify'
+  | 'clarify_handoff'
+  | 'model_not_found';
 
 export async function attemptKbAutoReply(
   prisma: PrismaClient,
@@ -117,11 +131,70 @@ export async function attemptKbAutoReply(
     `[KbAutoReply] conv=${conversationId} kbResults=${results.length} topSim=${topSimilarity.toFixed(3)}`,
   );
 
-  // 8. Decide reply path
-  const needsClarify = !topResult || topSimilarity < chatSettings.clarifyThreshold;
+  // 7.5 型號守門：客戶提到的型號若不在知識庫白名單，且 KB 相似度不夠高，
+  //     代表這可能是「查無此型號（打錯/記錯）」。此時不要拿相近型號的資料硬答，
+  //     改為引導客戶從相近型號清單中確認正確型號。
+  //     高相似度（>= MODEL_GUARD_EXEMPT_SIMILARITY）豁免，避免誤擋剛新增的型號。
   let replyText: string;
   let replyKind: ReplyKind;
   let metadataExtras: Record<string, unknown> = {};
+
+  const modelGuard = await checkModelGuard(
+    prisma,
+    tenantId,
+    messageText,
+    topSimilarity,
+  );
+
+  if (modelGuard) {
+    // 命中守門 → 引導選型號
+    const relatedList = modelGuard.relatedModels;
+    const guideContext =
+      relatedList.length > 0
+        ? `相近型號清單：\n${relatedList.join('\n')}`
+        : '';
+    try {
+      replyText = await generateReply(prisma, tenantId, messageText, guideContext, {
+        overrideSystemPrompt: chatSettings.modelGuideSystemPrompt || MODEL_GUIDE_SYSTEM_PROMPT,
+        history,
+      });
+    } catch (err) {
+      logger.error('[KbAutoReply] Model-guide generation failed, using fallback:', err);
+      replyText =
+        relatedList.length > 0
+          ? `不好意思，「${modelGuard.unknownModel}」這個型號我這邊查不到資料。` +
+            `想再幫您確認一下，您的產品是不是以下其中一款呢？\n${relatedList.join('\n')}\n` +
+            `型號通常印在產品本體底部標籤或外箱貼紙上，可以幫您對照看看。`
+          : `不好意思，「${modelGuard.unknownModel}」這個型號我這邊查不到資料，` +
+            `方便請您確認一下產品本體底部標籤或外箱貼紙上的正確型號嗎？`;
+    }
+    replyKind = 'model_not_found';
+    // 守門不應重置 clarify 計數，但也不該累加；維持原值即可（不寫入 metadataExtras）。
+    metadataExtras = {
+      modelGuard: {
+        unknownModel: modelGuard.unknownModel,
+        relatedModels: relatedList,
+        topSimilarity,
+      },
+    };
+    return await persistAndDeliver({
+      prisma,
+      io,
+      tenantId,
+      conversationId,
+      conversation,
+      botConfig,
+      replyText,
+      replyKind,
+      topResult,
+      results,
+      topSimilarity,
+      metadataExtras,
+    });
+  }
+
+  // 8. Decide reply path
+  const needsClarify = !topResult || topSimilarity < chatSettings.clarifyThreshold;
 
   if (needsClarify) {
     // Track clarify attempts in conversation.metadata to avoid loops
@@ -171,12 +244,102 @@ export async function attemptKbAutoReply(
     }
   }
 
-  // 8b. 決定要不要附 handoff prompt（只在 kb_with_handoff，kb_high_confidence 不附）
+  return await persistAndDeliver({
+    prisma,
+    io,
+    tenantId,
+    conversationId,
+    conversation,
+    botConfig,
+    replyText,
+    replyKind,
+    topResult,
+    results,
+    topSimilarity,
+    metadataExtras,
+  });
+}
+
+/**
+ * 型號守門檢查：判斷訊息是否提到「知識庫查無的型號」，需要引導使用者選型號。
+ *
+ * 回傳 null = 不攔截（沒提型號 / 型號已知 / KB 相似度夠高可豁免）。
+ * 回傳物件 = 攔截，附上查無的型號與相近型號清單。
+ *
+ * 只針對「第一個查無的型號」攔截（通常客戶一次問一台）。
+ */
+async function checkModelGuard(
+  prisma: PrismaClient,
+  tenantId: string,
+  messageText: string,
+  topSimilarity: number,
+): Promise<{ unknownModel: string; relatedModels: string[] } | null> {
+  const detected = detectModels(messageText);
+  if (detected.length === 0) return null;
+
+  // 高相似度豁免：KB 其實找到很像的文章，可能是白名單慢半拍，放行。
+  if (topSimilarity >= MODEL_GUARD_EXEMPT_SIMILARITY) return null;
+
+  let knownKeys: ReadonlySet<string>;
+  try {
+    knownKeys = await getKnownModelKeys(prisma, tenantId, Date.now());
+  } catch (err) {
+    // 白名單載入失敗時不要擋人，退回原本流程。
+    logger.error('[KbAutoReply] Failed to load model registry, skipping model guard:', err);
+    return null;
+  }
+
+  for (const model of detected) {
+    if (!isKnownModel(model, knownKeys)) {
+      const relatedModels = findRelatedModels(model, knownKeys);
+      logger.info(
+        `[KbAutoReply] model guard hit: "${model.raw}" (key=${model.key}) not in registry, ${relatedModels.length} related`,
+      );
+      return { unknownModel: model.raw, relatedModels };
+    }
+  }
+  return null;
+}
+
+/**
+ * 共用的「儲存 BOT 訊息 → 更新對話 → WebSocket 推送 → 送往 channel」流程。
+ * KB 正常回答路徑與型號守門路徑共用此函式。
+ */
+async function persistAndDeliver(input: {
+  prisma: PrismaClient;
+  io: Server;
+  tenantId: string;
+  conversationId: string;
+  conversation: { metadata: Prisma.JsonValue };
+  botConfig: BotConfig;
+  replyText: string;
+  replyKind: ReplyKind;
+  topResult: { id: string; title: string } | undefined;
+  results: Array<{ id: string; title: string; similarity: number }>;
+  topSimilarity: number;
+  metadataExtras: Record<string, unknown>;
+}): Promise<boolean> {
+  const {
+    prisma,
+    io,
+    tenantId,
+    conversationId,
+    conversation,
+    botConfig,
+    replyText,
+    replyKind,
+    topResult,
+    results,
+    topSimilarity,
+    metadataExtras,
+  } = input;
+
+  // 決定要不要附 handoff prompt（只在 kb_with_handoff，kb_high_confidence 不附）
   const kbReply = buildKbReplyPayload({ replyText, replyKind, botConfig });
   // 真正送 channel 的文字（可能多帶 text suffix）— DB 也存這份以利客服 UI 對齊
   const finalText = kbReply.text;
 
-  // 9. Persist BOT message
+  // Persist BOT message
   const now = new Date();
   const botMessage = await prisma.message.create({
     data: {
@@ -192,12 +355,13 @@ export async function attemptKbAutoReply(
         articleId: topResult?.id,
         articleTitle: topResult?.title,
         allResults: results.map((r) => ({ id: r.id, title: r.title, similarity: r.similarity })),
+        ...metadataExtras,
       },
       createdAt: now,
     },
   });
 
-  // 10. Update conversation (counters + clarifyAttempts)
+  // Update conversation (counters + clarifyAttempts / modelGuard)
   const existingMeta = (conversation.metadata ?? {}) as Record<string, unknown>;
   await prisma.conversation.update({
     where: { id: conversationId },
@@ -208,7 +372,7 @@ export async function attemptKbAutoReply(
     },
   });
 
-  // 11. Real-time
+  // Real-time
   const wsPayload = {
     conversationId,
     message: {
@@ -226,10 +390,10 @@ export async function attemptKbAutoReply(
   io.to(`conversation:${conversationId}`).emit('message.new', wsPayload);
   io.to(`tenant:${tenantId}`).emit('message.new', wsPayload);
 
-  // 12. Deliver to actual channel
+  // Deliver to actual channel
   // 命中 KB 的回答附「👎 沒幫到我」回報按鈕（quick reply postback），供調教 KB。
   // 加上 handoff_request 按鈕（依 botConfig.handoffPromptStyle）給使用者一鍵轉接。
-  // clarify / clarify_handoff 那種沒命中 KB 的不附（沒對應文章可回報、也不附轉接按鈕）。
+  // clarify / clarify_handoff / model_not_found 沒命中 KB 文章，不附「沒幫到我」按鈕。
   const hitKb = replyKind === 'kb_high_confidence' || replyKind === 'kb_with_handoff';
   const quickReplies: Array<{ label: string; postbackData: string }> = [];
   if (hitKb && topResult?.id) {

--- a/apps/api/src/modules/ai/llm.service.ts
+++ b/apps/api/src/modules/ai/llm.service.ts
@@ -61,6 +61,26 @@ export const CLARIFY_SYSTEM_PROMPT =
   '6. 整體控制在 2 句話以內\n' +
   '7. 不要編造或假設客戶的需求';
 
+/**
+ * Default system prompt used when the customer mentions a product model that
+ * does NOT exist in the knowledge base (e.g. typo / wrong model code).
+ * Instead of answering with a similar-but-wrong model's data, the bot should
+ * tell the customer the model wasn't found and guide them to pick the correct
+ * one from the list of related models we DO have.
+ *
+ * 相近型號清單會以 kbContext 的形式傳入（每行一個型號）。
+ */
+export const MODEL_GUIDE_SYSTEM_PROMPT =
+  '你是「Open333」品牌的客服助手。客戶提到的產品「型號」在知識庫中查不到，' +
+  '可能是輸入有誤或記錯型號。請用繁體中文引導客戶確認正確型號，規則如下：\n' +
+  '1. 先客氣告知：這個型號我這邊查不到資料，想再幫您確認一下。\n' +
+  '2. 若下方提供了「相近型號清單」，請把清單中的型號列出來，詢問客戶實際是哪一台' +
+  '（例如：「我們的 11 人份電鍋有這些型號，您的是哪一台呢？」）。\n' +
+  '3. 提醒客戶：型號通常印在產品本體底部的標籤，或外箱貼紙上，可以對照確認。\n' +
+  '4. 絕對不可自行假設客戶是清單中的某一台、也不可拿相近型號的規格直接回答。\n' +
+  '5. 不要編造清單以外的型號。若清單為空，只需請客戶提供／確認正確型號即可。\n' +
+  '6. 語氣親切，整體控制在 3-4 句話內。';
+
 type PromptKind = 'reply' | 'summarize';
 
 /**

--- a/apps/api/src/modules/ai/model-matcher.ts
+++ b/apps/api/src/modules/ai/model-matcher.ts
@@ -1,0 +1,122 @@
+/**
+ * Model Matcher — 純函式工具，負責「型號偵測 / 正規化 / 相近型號比對」。
+ *
+ * 背景：大同產品型號為三段式結構，例如 `TAC-11A-MB`：
+ *   ┌─ 前綴（品類碼）  ┌─ 人份+系列（第1段）  ┌─ 變體碼（第3段，選用）
+ *   TAC             - 11A                  - MB
+ *
+ * 重點設計：
+ * 1. 比對只看「前綴 + 第1段」（如 `TAC-11A`），不要求第3段（顏色/聯名/電壓）一致。
+ *    因為第3段多為變體，知識庫常不會收錄全部變體，太嚴會誤擋。
+ * 2. 「相近型號」= 同前綴 + 同人份數（如 `TAC-11*`）的所有已知型號，供引導使用者選。
+ *
+ * 此檔不碰資料庫，只處理字串。型號白名單由 model-registry.service 提供。
+ */
+
+/**
+ * 型號偵測正則。
+ * - 前綴：2~4 個大寫英文字母（TAC / TF / TAW / TDH / TOT / TEK …）
+ * - 緊接 `-` 與至少一段「英數」，後面可再接多段 `-英數`
+ * 例：TAC-11P-MFB、TAW-A080WM、TDH-168MC-NW、AC-9
+ */
+const MODEL_PATTERN = /\b([A-Z]{1,4})-([0-9A-Z]+(?:-[0-9A-Z]+)*)\b/gi;
+
+/** 從「第1段」抽出人份數字（型號開頭的連續數字），抓不到回傳 null。 */
+function extractCapacityDigits(firstSegment: string): string | null {
+  const m = firstSegment.match(/^(\d+)/);
+  return m ? m[1] : null;
+}
+
+export interface ParsedModel {
+  /** 正規化後的完整輸入型號（大寫、去空白），例：TAC-11P-MFB */
+  raw: string;
+  /** 前綴品類碼，例：TAC */
+  prefix: string;
+  /** 第1段（人份+系列），例：11P */
+  firstSegment: string;
+  /** 比對主鍵（前綴 + 第1段），例：TAC-11P */
+  key: string;
+  /** 人份數字（抓不到為 null），例：11 */
+  capacity: string | null;
+}
+
+/**
+ * 從一段文字中偵測所有型號 pattern，回傳解析後的型號陣列（去重、保留出現順序）。
+ * 沒有偵測到任何型號時回傳空陣列。
+ */
+export function detectModels(text: string): ParsedModel[] {
+  if (!text) return [];
+  const seen = new Set<string>();
+  const out: ParsedModel[] = [];
+
+  // matchAll 需要 global flag；用副本避免共用 lastIndex 狀態。
+  const re = new RegExp(MODEL_PATTERN.source, 'gi');
+  for (const match of text.matchAll(re)) {
+    const prefix = match[1].toUpperCase();
+    const rest = match[2].toUpperCase();
+    const segments = rest.split('-');
+    const firstSegment = segments[0];
+
+    // 第1段必須以數字開頭才視為「人份型號」（排除像 S02/S03 之類特例不在此守門）
+    // 註：若需涵蓋無人份數的型號，可放寬此條件。
+    const raw = `${prefix}-${rest}`;
+    const key = `${prefix}-${firstSegment}`;
+    if (seen.has(raw)) continue;
+    seen.add(raw);
+
+    out.push({
+      raw,
+      prefix,
+      firstSegment,
+      key,
+      capacity: extractCapacityDigits(firstSegment),
+    });
+  }
+  return out;
+}
+
+/**
+ * 判斷某個解析後的型號，其比對主鍵（前綴+第1段）是否存在於白名單。
+ * 白名單應為「主鍵集合」（如 'TAC-11A'），由 model-registry 產生。
+ */
+export function isKnownModel(parsed: ParsedModel, knownKeys: ReadonlySet<string>): boolean {
+  return knownKeys.has(parsed.key);
+}
+
+/**
+ * 找出與輸入型號「相近」的已知型號，用於引導使用者選擇。
+ * 相近定義：同前綴 + 同人份數（例：TAC-11P 找不到 → 列出所有 TAC-11* 已知型號）。
+ *
+ * @param parsed     使用者輸入的（查無的）型號
+ * @param knownKeys  白名單主鍵集合（如 TAC-11A、TAC-11KN…）
+ * @param limit      最多回傳幾個（預設 12，避免訊息過長）
+ * @returns          相近型號主鍵陣列（已排序），可能為空
+ */
+export function findRelatedModels(
+  parsed: ParsedModel,
+  knownKeys: ReadonlySet<string>,
+  limit = 12,
+): string[] {
+  const related: string[] = [];
+  for (const key of knownKeys) {
+    if (key === parsed.key) continue;
+    // 同前綴
+    const [prefix, firstSeg] = splitKey(key);
+    if (prefix !== parsed.prefix) continue;
+    // 同人份數（若輸入沒有人份數，退而求其次只比前綴）
+    if (parsed.capacity) {
+      const cap = firstSeg.match(/^(\d+)/)?.[1] ?? null;
+      if (cap !== parsed.capacity) continue;
+    }
+    related.push(key);
+  }
+  related.sort();
+  return related.slice(0, limit);
+}
+
+/** 將主鍵拆回 [前綴, 第1段]，例：'TAC-11A' → ['TAC', '11A']。 */
+function splitKey(key: string): [string, string] {
+  const idx = key.indexOf('-');
+  if (idx < 0) return [key, ''];
+  return [key.slice(0, idx), key.slice(idx + 1)];
+}

--- a/apps/api/src/modules/ai/model-registry.service.ts
+++ b/apps/api/src/modules/ai/model-registry.service.ts
@@ -1,0 +1,91 @@
+/**
+ * Model Registry — 動態維護「知識庫已知型號白名單」（per-tenant）。
+ *
+ * 設計（B 方案）：
+ * - 白名單不寫死，而是即時掃 km_articles 標題抽出所有型號主鍵（前綴+第1段）。
+ *   客服新增 KB 文章 → 下次快取刷新時自動納入，無需改程式或更版。
+ * - 記憶體快取 + TTL：避免每則訊息都掃全表；TTL 到期才重抽。
+ * - 提供 invalidate() 手動清快取，供「立即刷新」API 使用（新增文章後不想等 TTL）。
+ *
+ * 注意：此快取為單一 API process 的記憶體快取。多 process 部署時，各 process
+ * 的快取獨立過期；手動刷新只清當前 process。以 TTL 為主、手動刷新為輔即可。
+ */
+
+import type { PrismaClient } from '@prisma/client';
+import { logger } from '@open333crm/core';
+import { detectModels } from './model-matcher.js';
+
+/** 白名單快取存活時間（毫秒）。預設 10 分鐘。 */
+const CACHE_TTL_MS = 10 * 60 * 1000;
+
+interface CacheEntry {
+  /** 型號比對主鍵集合（如 TAC-11A、TAC-11KN…） */
+  keys: Set<string>;
+  /** 抽取自多少篇文章標題（log / 診斷用） */
+  sourceCount: number;
+  /** 此快取的到期時間戳（epoch ms） */
+  expiresAt: number;
+}
+
+/** tenantId → 快取。 */
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * 取得指定租戶的型號白名單（主鍵集合）。
+ * 快取有效則直接回；過期或不存在則重抽。
+ *
+ * @param now 目前時間戳（epoch ms）。由呼叫端傳入以利測試（沙箱禁用 Date.now）。
+ */
+export async function getKnownModelKeys(
+  prisma: PrismaClient,
+  tenantId: string,
+  now: number,
+): Promise<ReadonlySet<string>> {
+  const cached = cache.get(tenantId);
+  if (cached && cached.expiresAt > now) {
+    return cached.keys;
+  }
+  return refreshModelKeys(prisma, tenantId, now);
+}
+
+/**
+ * 強制重抽指定租戶的型號白名單並更新快取，回傳新的主鍵集合。
+ * 供 getKnownModelKeys 內部用，也供「手動刷新」API 直接呼叫。
+ */
+export async function refreshModelKeys(
+  prisma: PrismaClient,
+  tenantId: string,
+  now: number,
+): Promise<ReadonlySet<string>> {
+  const rows = await prisma.kmArticle.findMany({
+    where: { tenantId, status: 'PUBLISHED' },
+    select: { title: true },
+  });
+
+  const keys = new Set<string>();
+  for (const row of rows) {
+    for (const parsed of detectModels(row.title)) {
+      keys.add(parsed.key);
+    }
+  }
+
+  cache.set(tenantId, {
+    keys,
+    sourceCount: rows.length,
+    expiresAt: now + CACHE_TTL_MS,
+  });
+
+  logger.info(
+    `[ModelRegistry] tenant=${tenantId} refreshed: ${keys.size} models from ${rows.length} articles`,
+  );
+  return keys;
+}
+
+/**
+ * 清除指定租戶的快取（不立即重抽）。下次 getKnownModelKeys 會重抽。
+ * 適合掛在「KB 文章新增/發布」事件後，讓新型號儘快生效。
+ */
+export function invalidateModelCache(tenantId: string): void {
+  cache.delete(tenantId);
+  logger.info(`[ModelRegistry] tenant=${tenantId} cache invalidated`);
+}

--- a/apps/api/src/modules/knowledge/knowledge.routes.ts
+++ b/apps/api/src/modules/knowledge/knowledge.routes.ts
@@ -26,6 +26,7 @@ import {
   getFeedbackCounts,
   resolveFeedback,
 } from './kb-feedback.service.js';
+import { refreshModelKeys, getKnownModelKeys } from '../ai/model-registry.service.js';
 import { requireSupervisor } from '../../guards/rbac.guard.js';
 import { AppError, success, paginated } from '../../shared/utils/response.js';
 
@@ -302,6 +303,28 @@ export default async function knowledgeRoutes(fastify: FastifyInstance) {
     const status = await checkOllamaHealth(fastify.prisma, request.agent.tenantId);
     return reply.send(success(status));
   });
+
+  // ── 型號白名單（型號守門用）────────────────────────────────────────────────
+
+  // GET /api/v1/knowledge/models — 目前知識庫已知型號清單（快取，供診斷）
+  fastify.get('/models', async (request, reply) => {
+    const keys = await getKnownModelKeys(fastify.prisma, request.agent.tenantId, Date.now());
+    const models = [...keys].sort();
+    return reply.send(success({ total: models.length, models }));
+  });
+
+  // POST /api/v1/knowledge/models/refresh — 立即重抽型號白名單（清快取後重建）
+  // 客服新增型號文章後不想等 TTL（10 分鐘）自動刷新時使用。
+  fastify.post(
+    '/models/refresh',
+    { preHandler: [requireSupervisor()] },
+    async (request, reply) => {
+      const keys = await refreshModelKeys(fastify.prisma, request.agent.tenantId, Date.now());
+      return reply.send(
+        success({ refreshed: true, total: keys.size, message: `已重新整理型號清單，共 ${keys.size} 個型號。` }),
+      );
+    },
+  );
 
   // ── KB 回報（AI 回答品質回饋）────────────────────────────────────────────
 

--- a/apps/api/src/modules/settings/chat-settings.service.ts
+++ b/apps/api/src/modules/settings/chat-settings.service.ts
@@ -18,6 +18,7 @@ export interface ChatSettings {
   chatSystemPrompt: string;
   summarizeSystemPrompt: string;
   clarifySystemPrompt: string;
+  modelGuideSystemPrompt: string;
   clarifyThreshold: number;
   clarifyMaxAttempts: number;
 }
@@ -32,6 +33,7 @@ export const DEFAULT_CHAT_SETTINGS: ChatSettings = {
   chatSystemPrompt: '',
   summarizeSystemPrompt: '',
   clarifySystemPrompt: '',
+  modelGuideSystemPrompt: '',
   clarifyThreshold: 0.5,
   clarifyMaxAttempts: 2,
 };
@@ -53,6 +55,7 @@ export async function getChatSettings(
     chatSystemPrompt: s.chatSystemPrompt,
     summarizeSystemPrompt: s.summarizeSystemPrompt,
     clarifySystemPrompt: s.clarifySystemPrompt,
+    modelGuideSystemPrompt: s.modelGuideSystemPrompt,
     clarifyThreshold: s.clarifyThreshold,
     clarifyMaxAttempts: s.clarifyMaxAttempts,
   };
@@ -78,6 +81,7 @@ export async function updateChatSettings(
       chatSystemPrompt: next.chatSystemPrompt,
       summarizeSystemPrompt: next.summarizeSystemPrompt,
       clarifySystemPrompt: next.clarifySystemPrompt,
+      modelGuideSystemPrompt: next.modelGuideSystemPrompt,
       clarifyThreshold: next.clarifyThreshold,
       clarifyMaxAttempts: next.clarifyMaxAttempts,
     },
@@ -93,6 +97,7 @@ export async function updateChatSettings(
       chatSystemPrompt: updated.chatSystemPrompt,
       summarizeSystemPrompt: updated.summarizeSystemPrompt,
       clarifySystemPrompt: updated.clarifySystemPrompt,
+      modelGuideSystemPrompt: updated.modelGuideSystemPrompt,
       clarifyThreshold: updated.clarifyThreshold,
       clarifyMaxAttempts: updated.clarifyMaxAttempts,
     },

--- a/apps/api/src/modules/settings/settings.routes.ts
+++ b/apps/api/src/modules/settings/settings.routes.ts
@@ -26,6 +26,7 @@ import {
   CRM_REPLY_SYSTEM_PROMPT,
   SUMMARIZE_SYSTEM_PROMPT,
   CLARIFY_SYSTEM_PROMPT,
+  MODEL_GUIDE_SYSTEM_PROMPT,
 } from '../ai/llm.service.js';
 import { requireSupervisor } from '../../guards/rbac.guard.js';
 
@@ -132,6 +133,7 @@ export default async function settingsRoutes(fastify: FastifyInstance) {
           chatSystemPrompt: CRM_REPLY_SYSTEM_PROMPT,
           summarizeSystemPrompt: SUMMARIZE_SYSTEM_PROMPT,
           clarifySystemPrompt: CLARIFY_SYSTEM_PROMPT,
+          modelGuideSystemPrompt: MODEL_GUIDE_SYSTEM_PROMPT,
         },
       }),
     );
@@ -238,6 +240,7 @@ const chatSettingsSchema = z.object({
   chatSystemPrompt: z.string().optional(),
   summarizeSystemPrompt: z.string().optional(),
   clarifySystemPrompt: z.string().optional(),
+  modelGuideSystemPrompt: z.string().optional(),
   clarifyThreshold: z.number().min(0).max(1).optional(),
   clarifyMaxAttempts: z.number().int().min(0).max(5).optional(),
 });

--- a/apps/web/src/components/knowledge/ChatPromptSettings.tsx
+++ b/apps/web/src/components/knowledge/ChatPromptSettings.tsx
@@ -15,6 +15,7 @@ interface ChatSettingsData {
   chatSystemPrompt: string;
   summarizeSystemPrompt: string;
   clarifySystemPrompt: string;
+  modelGuideSystemPrompt: string;
   clarifyThreshold: number;
   clarifyMaxAttempts: number;
 }
@@ -49,6 +50,7 @@ interface SettingsResponse {
     chatSystemPrompt: string;
     summarizeSystemPrompt: string;
     clarifySystemPrompt: string;
+    modelGuideSystemPrompt: string;
   };
 }
 
@@ -61,6 +63,7 @@ const DEFAULT_SETTINGS: ChatSettingsData = {
   chatSystemPrompt: '',
   summarizeSystemPrompt: '',
   clarifySystemPrompt: '',
+  modelGuideSystemPrompt: '',
   clarifyThreshold: 0.5,
   clarifyMaxAttempts: 2,
 };
@@ -74,6 +77,7 @@ export function ChatPromptSettings() {
     chatSystemPrompt: '',
     summarizeSystemPrompt: '',
     clarifySystemPrompt: '',
+    modelGuideSystemPrompt: '',
   });
 
   const [loading, setLoading] = useState(true);
@@ -134,6 +138,22 @@ export function ChatPromptSettings() {
       alert('儲存失敗');
     } finally {
       setSaving(false);
+    }
+  };
+
+  const [refreshingModels, setRefreshingModels] = useState(false);
+  const refreshModelRegistry = async () => {
+    setRefreshingModels(true);
+    try {
+      const res = await api.post<{ data: { total: number; message: string } }>(
+        '/knowledge/models/refresh',
+      );
+      alert(res.data.data.message ?? '已重新整理型號清單');
+    } catch (err) {
+      console.error('Failed to refresh model registry:', err);
+      alert('刷新型號清單失敗');
+    } finally {
+      setRefreshingModels(false);
     }
   };
 
@@ -436,6 +456,61 @@ export function ChatPromptSettings() {
           <Button onClick={() => persistSettings(settings)} disabled={saving}>
             {saving ? '儲存中…' : '儲存'}
           </Button>
+        </div>
+      </section>
+
+      {/* ─── System Prompt：型號守門引導 ────────────────────────── */}
+      <section className="rounded-lg border bg-card p-5">
+        <div className="flex items-start justify-between">
+          <div>
+            <h3 className="text-sm font-semibold">型號引導 System Prompt</h3>
+            <p className="mt-1 text-xs text-muted-foreground">
+              當客戶提到「知識庫查不到的產品型號」（可能打錯/記錯）時，Bot 會用此提示詞引導客戶
+              從相近型號清單確認正確型號，而不是拿相似型號的資料硬答。留空表示使用預設提示詞。
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              setSettings({ ...settings, modelGuideSystemPrompt: defaults.modelGuideSystemPrompt })
+            }
+          >
+            還原預設
+          </Button>
+        </div>
+        <textarea
+          className="mt-3 min-h-[160px] w-full rounded-md border bg-background p-3 font-mono text-xs"
+          value={settings.modelGuideSystemPrompt}
+          onChange={(e) => setSettings({ ...settings, modelGuideSystemPrompt: e.target.value })}
+          placeholder={defaults.modelGuideSystemPrompt}
+        />
+        <div className="mt-2 flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">
+            {settings.modelGuideSystemPrompt.length} 字
+            {settings.modelGuideSystemPrompt.length === 0 && '（將使用預設）'}
+          </span>
+          <Button onClick={() => persistSettings(settings)} disabled={saving}>
+            {saving ? '儲存中…' : '儲存'}
+          </Button>
+        </div>
+
+        {/* 型號白名單刷新 */}
+        <div className="mt-4 rounded-md bg-muted/50 p-3">
+          <div className="flex items-start justify-between gap-3">
+            <p className="text-xs text-muted-foreground">
+              型號清單會自動從知識庫文章標題抽取（約每 10 分鐘刷新）。新增型號文章後若想立即生效，
+              可手動刷新。
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={refreshModelRegistry}
+              disabled={refreshingModels}
+            >
+              {refreshingModels ? '刷新中…' : '立即刷新型號清單'}
+            </Button>
+          </div>
         </div>
       </section>
 

--- a/packages/database/prisma/migrations/20260617000000_add_model_guide_system_prompt/migration.sql
+++ b/packages/database/prisma/migrations/20260617000000_add_model_guide_system_prompt/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "tenant_settings" ADD COLUMN     "modelGuideSystemPrompt" TEXT NOT NULL DEFAULT '';

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1026,6 +1026,7 @@ model TenantSettings {
   chatSystemPrompt       String   @default("")
   summarizeSystemPrompt  String   @default("")
   clarifySystemPrompt    String   @default("")
+  modelGuideSystemPrompt String   @default("")
   clarifyThreshold       Float    @default(0.5)
   clarifyMaxAttempts     Int      @default(2)
   inactivityCloseHours   Int      @default(72)


### PR DESCRIPTION
## 背景

延續 #128（AI 客服防幻覺）。實測發現另一類幻覺：客戶詢問**知識庫不存在的型號**時（例如 `TAC-11P-MFB`），純向量檢索會找到字面最像的相鄰型號（`TAC-11A`，相似度 0.72），並拿其資料硬答，給出錯誤的產品資訊。

知識庫實際查證：`TAC-11P` 整個系列碼不存在（11 人份只有 11A/11EA/11KN/11KST… 沒有 11P）。

## 解法：型號守門（Model Guard）

偵測訊息中的型號 → 比對「知識庫已知型號白名單」→ 不在白名單且 KB 相似度未達豁免門檻（0.85）→ **攔截**，改引導客戶從相近型號清單確認正確型號，而非拿相似型號亂答。

### 不用每次更版
白名單**從 `km_articles` 標題動態抽取**（per-tenant，記憶體快取 10 分鐘 TTL）。客服新增型號文章即自動納入，無需改程式或部署。等不及 TTL 可用手動刷新 API。

### 防誤擋設計
- 型號比對只看「前綴+第1段」（人份+系列），第3段變體（顏色/聯名/電壓如 `-MB`）不要求一致 → 不誤擋變體
- 高相似度（≥0.85）豁免 → 白名單慢半拍但 KB 其實有對應文章時仍正常回答

## 變更內容

**後端**
- `ai/model-matcher.ts`（新）：型號偵測、正規化到主鍵、找相近型號（純函式）
- `ai/model-registry.service.ts`（新）：動態白名單 + 快取 + 手動刷新
- `ai/kb-autoreply.service.ts`：插入型號守門；新 replyKind `model_not_found`；抽出共用 `persistAndDeliver()`
- `ai/llm.service.ts`：新增 `MODEL_GUIDE_SYSTEM_PROMPT` 引導話術
- `settings/chat-settings.service.ts` + `settings.routes.ts`：新增 `modelGuideSystemPrompt`（可後台覆蓋）
- `knowledge.routes.ts`：`GET /knowledge/models`（看白名單）、`POST /knowledge/models/refresh`（手動刷新，需 Supervisor）

**前端**
- `ChatPromptSettings.tsx`：新增「型號引導 System Prompt」textarea + 還原預設 + 「立即刷新型號清單」按鈕

**資料庫**
- migration：`tenant_settings` 加 `modelGuideSystemPrompt TEXT DEFAULT ''`

## 驗證
- API / Web `tsc --noEmit` 皆 EXIT=0
- 型號偵測核心邏輯煙霧測試通過：
  - `TAC-11P-MFB` → 攔截，列出 11 人份相近型號 ✅
  - `TAC-11A` / `TAC-11A-MB`（變體）→ 正常回答，不誤擋 ✅
  - 沒提型號 → 不干涉 ✅

## 部署注意
- 含 Prisma migration（entrypoint 跑 `migrate deploy` 會自動套用）
- 新功能預設啟用，引導話術留空則用內建預設

🤖 Generated with [Claude Code](https://claude.com/claude-code)