### PR TITLE
feat: KB 上傳 QA 表格自動拆成一題一篇（防大表復發）

### DIFF
--- a/apps/api/src/modules/knowledge/file-parser.service.ts
+++ b/apps/api/src/modules/knowledge/file-parser.service.ts
@@ -101,6 +101,72 @@ function parsePlainText(buffer: Buffer): string {
   return buffer.toString('utf-8').trim();
 }
 
+/** 拆列匯入用：一列 QA = 一篇文章。 */
+export interface QaRow {
+  title: string;
+  content: string;
+}
+
+/** 可辨識為「問題欄」的表頭關鍵字（大小寫不拘）。 */
+const QUESTION_HEADERS = ['ai_q', 'question', '問題', '問', 'q', 'title', '標題'];
+/** 可辨識為「答案欄」的表頭關鍵字。 */
+const ANSWER_HEADERS = ['ai_a', 'answer', '答案', '答', 'a', 'content', '內容', '回覆'];
+
+function normalizeHeader(h: string): string {
+  return String(h ?? '').trim().toLowerCase();
+}
+
+/**
+ * 偵測試算表是否為「QA 表格」並回傳問/答欄的索引。
+ * 找不到可辨識的問答欄則回傳 null（代表不該拆，照單篇處理）。
+ */
+function detectQaColumns(header: string[]): { qIdx: number; aIdx: number } | null {
+  const norm = header.map(normalizeHeader);
+  const qIdx = norm.findIndex((h) => QUESTION_HEADERS.includes(h));
+  const aIdx = norm.findIndex((h) => ANSWER_HEADERS.includes(h));
+  if (qIdx === -1 || aIdx === -1 || qIdx === aIdx) return null;
+  return { qIdx, aIdx };
+}
+
+/**
+ * 嘗試把 xlsx/csv 拆成「一列一篇 QA」。
+ * - 掃所有 sheet，找出有 QA 欄的表頭
+ * - 每資料列以問欄為 title、答欄為 content
+ * - 兩欄皆空的列略過；跨 sheet 同 Q+A 去重
+ * 回傳 null 代表「偵測不到 QA 結構」→ 呼叫端應改走單篇匯入。
+ */
+export function parseSpreadsheetToQaRows(buffer: Buffer): QaRow[] | null {
+  const workbook = XLSX.read(buffer, { type: 'buffer' });
+  const rows: QaRow[] = [];
+  const seen = new Set<string>();
+  let detectedAnySheet = false;
+
+  for (const sheetName of workbook.SheetNames) {
+    const sheet = workbook.Sheets[sheetName];
+    const grid: unknown[][] = XLSX.utils.sheet_to_json(sheet, { header: 1 }) as unknown[][];
+    if (grid.length < 2) continue;
+
+    const header = grid[0].map((c) => String(c ?? ''));
+    const cols = detectQaColumns(header);
+    if (!cols) continue;
+    detectedAnySheet = true;
+
+    for (let i = 1; i < grid.length; i++) {
+      const cells = grid[i] ?? [];
+      const q = String(cells[cols.qIdx] ?? '').replace(/&nbsp;/g, ' ').trim();
+      const a = String(cells[cols.aIdx] ?? '').replace(/&nbsp;/g, ' ').trim();
+      if (!q || !a) continue;
+      const key = q + '||' + a;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      rows.push({ title: q.slice(0, 200), content: a });
+    }
+  }
+
+  if (!detectedAnySheet) return null; // 沒有任何 sheet 像 QA 表
+  return rows;
+}
+
 export async function parseFileToMarkdown(
   buffer: Buffer,
   mimetype: string,

--- a/apps/api/src/modules/knowledge/knowledge.routes.ts
+++ b/apps/api/src/modules/knowledge/knowledge.routes.ts
@@ -15,7 +15,7 @@ import {
   checkOllamaHealth,
   embedArticle,
 } from './knowledge.service.js';
-import { parseFileToMarkdown } from './file-parser.service.js';
+import { parseFileToMarkdown, parseSpreadsheetToQaRows } from './file-parser.service.js';
 import {
   ingestPartnerDoc,
   parseCmd,
@@ -133,6 +133,32 @@ export default async function knowledgeRoutes(fastify: FastifyInstance) {
     for await (const part of parts) {
       const buffer = await part.toBuffer();
       try {
+        // xlsx/csv 若偵測到 QA 表結構（有問/答欄），自動拆成「一列一篇」，
+        // 避免整張表變成單篇大文章（答案被埋沒、無法檢索）。
+        const isSheet =
+          /spreadsheetml|csv/.test(part.mimetype) ||
+          /\.(xlsx|csv)$/i.test(part.filename);
+        if (isSheet) {
+          const qaRows = parseSpreadsheetToQaRows(buffer);
+          if (qaRows && qaRows.length > 0) {
+            const result = await batchImportArticles(
+              fastify.prisma,
+              request.agent.tenantId,
+              request.agent.id,
+              qaRows.map((r) => ({ title: r.title, content: r.content, status: 'PUBLISHED' })),
+            );
+            uploaded += result.imported;
+            failed += result.failed;
+            results.push({
+              title: `${part.filename}（QA 表自動拆成 ${result.imported} 篇）`,
+              success: result.failed === 0,
+              error: result.errors[0],
+            });
+            continue;
+          }
+          // 偵測不到 QA 欄 → 落到下方單篇匯入
+        }
+
         const parsed = await parseFileToMarkdown(buffer, part.mimetype, part.filename);
         await createArticle(fastify.prisma, request.agent.tenantId, request.agent.id, {
           title: parsed.title,


### PR DESCRIPTION
## 背景
延續拆 `ChatBot_客服-QA` 102 萬字大表（PR #131）。那篇是 QA Excel 從 `/upload` 整張表渲染成**單篇**所致 → 答案被埋沒、檢索不到 → 大量無謂轉接 / 幻覺。

拆掉現有的只是「清掉中毒文章」，但 `/upload` 的水龍頭還開著——再上傳一張 QA 表又會變大表。本 PR 防復發。

## 變更
- `file-parser.service.ts`：新增 `parseSpreadsheetToQaRows()`
  - 偵測問/答欄（`AI_Q`/`AI_A`、`問題`/`答案`、`question`/`answer` 等中英關鍵字）
  - 逐列拆成 `{title, content}`，空列略過、跨 sheet 去重
  - **非 QA 表（如規格表）回傳 null** → 不誤拆
- `knowledge.routes.ts`：`/upload` 對 xlsx/csv 先試 `parseSpreadsheetToQaRows`
  - 偵測到 QA 表 → `batchImportArticles` 拆成多篇（各自 embedding）
  - 偵測不到 → 回退原本單篇匯入

## 驗證
- API `tsc --noEmit` EXIT=0
- 單元驗證（餵 XLSX buffer）：
  - 標準 QA 表（AI_Q/AI_A）→ 拆多篇、空列略過、去重 ✅
  - 中文表頭（問題/答案）→ 認得 ✅
  - 規格表（型號/容量/功率）→ 回 null、回退單篇 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)