### PR TITLE
feat: 知識庫新增來源與 tag 篩選

### DIFF
--- a/apps/api/src/modules/knowledge/knowledge.routes.ts
+++ b/apps/api/src/modules/knowledge/knowledge.routes.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import {
   listArticles,
+  listSources,
   getArticle,
   createArticle,
   updateArticle,
@@ -85,12 +86,20 @@ export default async function knowledgeRoutes(fastify: FastifyInstance) {
     const result = await listArticles(fastify.prisma, request.agent.tenantId, {
       status: query.status || undefined,
       category: query.category || undefined,
+      source: query.source || undefined,
+      tag: query.tag || undefined,
       q: query.q || undefined,
       page,
       limit,
     });
 
     return reply.send(paginated(result.articles, result.total, result.page, result.limit));
+  });
+
+  // GET /api/v1/knowledge/sources — 來源列表（externalSource 去重）
+  fastify.get('/sources', async (request, reply) => {
+    const sources = await listSources(fastify.prisma, request.agent.tenantId);
+    return reply.send(success(sources));
   });
 
   // GET /api/v1/knowledge/categories — 分類列表

--- a/apps/api/src/modules/knowledge/knowledge.service.ts
+++ b/apps/api/src/modules/knowledge/knowledge.service.ts
@@ -17,21 +17,30 @@ export async function listArticles(
   filters: {
     status?: string;
     category?: string;
+    source?: string;
+    tag?: string;
     q?: string;
     page?: number;
     limit?: number;
   } = {},
 ) {
-  const { status, category, q, page = 1, limit = 50 } = filters;
+  const { status, category, source, tag, q, page = 1, limit = 50 } = filters;
 
   const where: Record<string, unknown> = { tenantId };
   if (status) where.status = status;
   if (category) where.category = category;
+  if (tag) where.tags = { has: tag };
+  // source: '__manual__' 代表手動建立（externalSource 為空），其餘為精確比對
+  if (source) {
+    where.externalSource = source === '__manual__' ? null : source;
+  }
   if (q) {
     where.OR = [
       { title: { contains: q, mode: 'insensitive' } },
       { summary: { contains: q, mode: 'insensitive' } },
       { content: { contains: q, mode: 'insensitive' } },
+      // tag 為陣列元素精確比對（輸入完整 tag 名稱才會命中）
+      { tags: { has: q } },
     ];
   }
 
@@ -267,6 +276,17 @@ export async function listCategories(prisma: PrismaClient, tenantId: string) {
   });
 
   return results.map((r) => r.category);
+}
+
+export async function listSources(prisma: PrismaClient, tenantId: string) {
+  const results = await prisma.kmArticle.findMany({
+    where: { tenantId, externalSource: { not: null } },
+    select: { externalSource: true },
+    distinct: ['externalSource'],
+    orderBy: { externalSource: 'asc' },
+  });
+
+  return results.map((r) => r.externalSource).filter(Boolean) as string[];
 }
 
 // ─── Semantic Search ────────────────────────────────────────────────────────

--- a/apps/web/src/app/dashboard/knowledge/page.tsx
+++ b/apps/web/src/app/dashboard/knowledge/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useCallback } from 'react';
 import { Plus, Upload, Search, Loader2, Brain, ThumbsDown, Check, Pencil } from 'lucide-react';
-import { useKnowledge, useCategories } from '@/hooks/useKnowledge';
+import { useKnowledge, useCategories, useSources } from '@/hooks/useKnowledge';
 import { useKbFeedbackList, resolveKbFeedback } from '@/hooks/useKbFeedback';
 import { ArticleList } from '@/components/knowledge/ArticleList';
 import { ArticleFormDialog } from '@/components/knowledge/ArticleFormDialog';
@@ -31,6 +31,8 @@ const PAGE_SIZE = 50;
 export default function KnowledgePage() {
   const [statusFilter, setStatusFilter] = useState('all');
   const [categoryFilter, setCategoryFilter] = useState('');
+  const [sourceFilter, setSourceFilter] = useState('');
+  const [tagFilter, setTagFilter] = useState('');
   const [search, setSearch] = useState('');
   const [page, setPage] = useState(1);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -69,6 +71,8 @@ export default function KnowledgePage() {
   const { articles, meta, isLoading, mutate } = useKnowledge({
     status: statusFilter === 'all' ? undefined : statusFilter,
     category: categoryFilter || undefined,
+    source: sourceFilter || undefined,
+    tag: tagFilter || undefined,
     q: search || undefined,
     page,
     limit: PAGE_SIZE,
@@ -80,9 +84,10 @@ export default function KnowledgePage() {
   // Reset to page 1 whenever filters change
   React.useEffect(() => {
     setPage(1);
-  }, [statusFilter, categoryFilter, search]);
+  }, [statusFilter, categoryFilter, sourceFilter, tagFilter, search]);
 
   const { categories } = useCategories();
+  const { sources } = useSources();
 
   const handleEdit = useCallback(async (article: any) => {
     try {
@@ -165,6 +170,12 @@ export default function KnowledgePage() {
     ...categories.map((c) => ({ value: c, label: c })),
   ];
 
+  const sourceOptions = [
+    { value: '', label: '全部來源' },
+    { value: '__manual__', label: '手動建立' },
+    ...sources.map((s) => ({ value: s, label: s })),
+  ];
+
   return (
     <div className="flex h-full flex-col">
       <Topbar title="知識庫" />
@@ -214,6 +225,24 @@ export default function KnowledgePage() {
                     className="w-40"
                   />
                 )}
+                {sources.length > 0 && (
+                  <Select
+                    value={sourceFilter}
+                    onChange={(e) => setSourceFilter(e.target.value)}
+                    options={sourceOptions}
+                    className="w-48"
+                  />
+                )}
+                {tagFilter && (
+                  <Badge
+                    variant="default"
+                    className="cursor-pointer gap-1"
+                    onClick={() => setTagFilter('')}
+                    title="點擊清除 tag 篩選"
+                  >
+                    Tag: {tagFilter} ✕
+                  </Badge>
+                )}
                 <div className="ml-auto flex items-center gap-2">
                   <Button variant="outline" size="sm" onClick={() => setImportOpen(true)}>
                     <Upload className="mr-1.5 h-4 w-4" />
@@ -247,6 +276,7 @@ export default function KnowledgePage() {
                 onPublish={handlePublish}
                 onArchive={handleArchive}
                 onDelete={handleDelete}
+                onTagClick={setTagFilter}
               />
             </div>
             {totalPages > 1 && (

--- a/apps/web/src/components/knowledge/ArticleList.tsx
+++ b/apps/web/src/components/knowledge/ArticleList.tsx
@@ -19,6 +19,7 @@ interface Article {
   hasEmbedding?: boolean;
   externalDocId?: string | null;
   externalVer?: number;
+  externalSource?: string | null;
   _count?: { attachments: number };
 }
 
@@ -29,6 +30,7 @@ interface ArticleListProps {
   onPublish: (id: string) => void;
   onArchive: (id: string) => void;
   onDelete: (id: string) => void;
+  onTagClick?: (tag: string) => void;
 }
 
 const statusLabel: Record<string, string> = {
@@ -50,6 +52,7 @@ export function ArticleList({
   onPublish,
   onArchive,
   onDelete,
+  onTagClick,
 }: ArticleListProps) {
   if (isLoading) {
     return (
@@ -114,8 +117,13 @@ export function ArticleList({
                         {article.summary}
                       </p>
                     )}
-                    {(article.externalDocId || (article._count?.attachments ?? 0) > 0) && (
+                    {(article.externalSource || article.externalDocId || (article._count?.attachments ?? 0) > 0) && (
                       <div className="mt-1 flex items-center gap-2 text-[10px] text-muted-foreground">
+                        {article.externalSource && (
+                          <Badge variant="outline" className="px-1 py-0 text-[10px] font-normal">
+                            {article.externalSource}
+                          </Badge>
+                        )}
                         {article.externalDocId && (
                           <span>
                             DocID {article.externalDocId}
@@ -144,7 +152,13 @@ export function ArticleList({
               <td className="px-4 py-3">
                 <div className="flex flex-wrap gap-1">
                   {article.tags.slice(0, 3).map((tag) => (
-                    <Badge key={tag} variant="secondary" className="text-xs">
+                    <Badge
+                      key={tag}
+                      variant="secondary"
+                      className={onTagClick ? 'cursor-pointer text-xs hover:bg-primary hover:text-primary-foreground' : 'text-xs'}
+                      onClick={() => onTagClick?.(tag)}
+                      title={onTagClick ? `篩選 tag：${tag}` : undefined}
+                    >
                       {tag}
                     </Badge>
                   ))}

--- a/apps/web/src/hooks/useKnowledge.ts
+++ b/apps/web/src/hooks/useKnowledge.ts
@@ -6,6 +6,8 @@ import api from '@/lib/api';
 interface KnowledgeFilters {
   status?: string;
   category?: string;
+  source?: string;
+  tag?: string;
   q?: string;
   page?: number;
   limit?: number;
@@ -17,11 +19,13 @@ const fetcher = async (url: string) => {
 };
 
 export function useKnowledge(filters: KnowledgeFilters = {}) {
-  const { status, category, q, page = 1, limit = 50 } = filters;
+  const { status, category, source, tag, q, page = 1, limit = 50 } = filters;
 
   const params = new URLSearchParams();
   if (status) params.set('status', status);
   if (category) params.set('category', category);
+  if (source) params.set('source', source);
+  if (tag) params.set('tag', tag);
   if (q) params.set('q', q);
   params.set('page', String(page));
   params.set('limit', String(limit));
@@ -36,6 +40,16 @@ export function useKnowledge(filters: KnowledgeFilters = {}) {
     isLoading,
     error,
     mutate,
+  };
+}
+
+export function useSources() {
+  const { data, error, isLoading } = useSWR('/knowledge/sources', fetcher);
+
+  return {
+    sources: (data?.data || []) as string[],
+    isLoading,
+    error,
   };
 }
 


### PR DESCRIPTION
## 摘要

大同逐字稿匯入 3,308 篇 DRAFT 後，知識庫列表新舊資料混在一起無法區分。本 PR 為知識庫加上「來源」與「tag」兩種篩選：

### API（apps/api）
- `GET /api/v1/knowledge` 新增 `source` 參數：`externalSource` 精確比對，特殊值 `__manual__` 代表手動建立（externalSource 為 null）
- `GET /api/v1/knowledge` 新增 `tag` 參數：tags 陣列元素精確比對（`has`）
- 新增 `GET /api/v1/knowledge/sources`：回傳該租戶 externalSource 去重清單（供下拉選單）
- 關鍵字搜尋 `q` 增加 tag 精確比對（輸入完整 tag 名稱可命中）

### Web（apps/web）
- 知識庫頁面：分類旁新增「來源」下拉（全部來源／手動建立／各 externalSource）
- 文章列表 tag 徽章可點擊 → 直接以該 tag 篩選；篩選中顯示可清除的標示徽章
- 文章列表標題下方顯示來源徽章

## 測試

- [x] `tsc --noEmit` api / web 皆通過
- [x] 本機實測：`/sources` 回傳 3 種來源；`source=kb-ingest:大同逐字稿` 篩得 3,308 篇；`tag=高信心待審` 篩得 299 篇；UI 點 tag 篩選與清除正常

## 相關背景

- 逐字稿→KB 管線（kb-ingest）產出 3,308 篇 DRAFT，高信心批 299 篇已依 tag 審核發布並同步 UAT
- UAT 部署本 PR 後，該環境也能以 tag「高信心待審」管理這批文章

🤖 Generated with [Claude Code](https://claude.com/claude-code)